### PR TITLE
Improving the dev workflow: Setup check for merge conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ CREDENTIALS=None
 # Details of the Spreadsheet used for CLA checking.
 SHEETS_API_CREDENTIALS=None
 SPREADSHEET_ID=None
+
+# This variable is used to put the first run of the scheduler on a random delay.
+DISABLE_DELAY=true

--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ module.exports = (robot) => {
         context.repo({number: pullRequestNumber}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
-        robot.log.error('MERGE CONFLICT PR');
-        robot.log.error(pullRequestNumber);
+        console.log('MERGE CONFLICT PR');
+        console.log(pullRequestNumber);
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -183,8 +183,7 @@ module.exports = (robot) => {
     for (var index in arrayOfOpenPullRequests) {
       pullRequestNumber = arrayOfOpenPullRequests[index].number;
       pullRequestDetails = context.github.pullRequests.get(
-        context.repo(
-          {number: pullRequestNumber}));
+        context.repo({number: pullRequestNumber}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 5 // 3 days
+    interval: 60 * 60 * 1000 * 24 * 3 // 3 days
   });
 
   var pullRequestAuthor;
@@ -177,20 +177,19 @@ module.exports = (robot) => {
   };
 
   var checkMergeConflicts = function(context) {
-    /*
     arrayOfOpenPullRequests = (
       context.github.pullRequests.getAll(context.repo()));
-    */
-    // for (var index in arrayOfOpenPullRequests) {
-      // pullRequestNumber = arrayOfOpenPullRequests[index].number;
+    for (var index in arrayOfOpenPullRequests) {
+      pullRequestNumber = arrayOfOpenPullRequests[index].number;
       console.log('INSIDE THE BLOCK');
       pullRequestDetails = context.github.pullRequests.get(
-        context.repo({number: 4740}));
+        context.repo({number: pullRequestNumber}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');
         console.log(pullRequestNumber);
       }
+    }
   };
 
   /*

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 5 // 3 days
+    interval: 60 * 60 * 1000 * 24 * 3 // 3 days
   });
 
   var pullRequestAuthor;
@@ -177,19 +177,19 @@ module.exports = (robot) => {
   };
 
   var checkMergeConflicts = function(context) {
+    /*
     arrayOfOpenPullRequests = (
       context.github.pullRequests.getAll(context.repo()));
-
-    for (var index in arrayOfOpenPullRequests) {
-      pullRequestNumber = arrayOfOpenPullRequests[index].number;
+    */
+    // for (var index in arrayOfOpenPullRequests) {
+      // pullRequestNumber = arrayOfOpenPullRequests[index].number;
       pullRequestDetails = context.github.pullRequests.get(
-        context.repo({number: pullRequestNumber}));
+        context.repo({number: 4740}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');
         console.log(pullRequestNumber);
       }
-    }
   };
 
   /*

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 1000 * 24 * 3 // 3 days
+    interval: 60 * 60 * 5 // 3 days
   });
 
   var pullRequestAuthor;
@@ -183,6 +183,7 @@ module.exports = (robot) => {
     */
     // for (var index in arrayOfOpenPullRequests) {
       // pullRequestNumber = arrayOfOpenPullRequests[index].number;
+      console.log('INSIDE THE BLOCK');
       pullRequestDetails = context.github.pullRequests.get(
         context.repo({number: 4740}));
       isMergeable = pullRequestDetails.mergeable;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 1000 // 3 days
+    interval: 60 * 60 * 5 // 3 days
   });
 
   var pullRequestAuthor;
@@ -186,8 +186,8 @@ module.exports = (robot) => {
         context.repo({number: pullRequestNumber}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
-        console.log('MERGE CONFLICT PR');
-        console.log(pullRequestNumber);
+        robot.log.error('MERGE CONFLICT PR');
+        robot.log.error(pullRequestNumber);
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 15 // 3 days
+    interval: 60 * 60 * 1000 // 3 days
   });
 
   var pullRequestAuthor;
@@ -177,18 +177,18 @@ module.exports = (robot) => {
   };
 
   var checkMergeConflicts = function(context) {
-    console.log('LIST OF ALL PRs');
-    arrayOfOpenPullRequests = context.github.pullRequests.getAll(context.repo());
+    arrayOfOpenPullRequests = (
+      context.github.pullRequests.getAll(context.repo()));
 
-    for (var key in arrayOfOpenPullRequests) {
-      pullRequestNumber = arrayOfOpenPullRequests[key].number;
-      //console.log('PULL REQUEST NUMBER');
-      //console.log(pullRequestNumber);
-      pullRequestDetails = context.github.pullRequests.get(context.repo({number: pullRequestNumber}));
+    for (var index in arrayOfOpenPullRequests) {
+      pullRequestNumber = arrayOfOpenPullRequests[index].number;
+      pullRequestDetails = context.github.pullRequests.get(
+        context.repo(
+          {number: pullRequestNumber}));
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');
-        console.log(typeof pullRequestNumber);
+        console.log(pullRequestNumber);
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ module.exports = (robot) => {
   };
 
   var checkMergeConflicts = async function(context) {
-    var mergeConflictLabel = ['Has Merge Conflicts'];
+    var mergeConflictLabel = ['PR: don\'t merge - HAS MERGE CONFLICTS'];
     pullRequestsPromiseObj = await context.github.pullRequests.getAll(
       context.repo());
 

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = (robot) => {
     arrayOfOpenPullRequests = pullRequestsPromiseObj.data;
     var hasMergeConflictLabel;
     for (var indexOfPullRequest in arrayOfOpenPullRequests) {
-      pullRequestNumber = await arrayOfOpenPullRequests[
+      pullRequestNumber = arrayOfOpenPullRequests[
         indexOfPullRequest].number;
       pullRequestDetailsPromiseObj = await context.github.pullRequests.get(
         context.repo({number: pullRequestNumber}));
@@ -206,7 +206,7 @@ module.exports = (robot) => {
         var linkText = 'link';
         var linkResult = linkText.link(
           'https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/');
-        var params = await context.repo({
+        var params = context.repo({
           number: pullRequestNumber,
           body: 'Hi @' + userName +
             '. The latest commit in this PR has resulted in ' +

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 1000 // 3 days
+    interval: 60 * 60 * 3 // 3 days
   });
 
   var pullRequestAuthor;
@@ -178,6 +178,7 @@ module.exports = (robot) => {
 
   var checkMergeConflicts = function(context) {
     var mergeConflictLabel = ['Has Merge Conflicts'];
+    console.log('BLOCK STARTING RANDOM CHARACTERS ARE BEING WRITTEN DOWN IN THE LOG')
     arrayOfOpenPullRequests = (
       context.github.pullRequests.getAll(context.repo()));
     for (var index in arrayOfOpenPullRequests) {

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ module.exports = (robot) => {
 
   var checkMergeConflicts = function(context) {
     console.log('LIST OF ALL PRs');
-    console.log(context.pullRequests.getAll(context.repo()));
+    console.log(context.github.pullRequests.getAll(context.repo()));
   };
 
   /*

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 // 3 days
+    interval: 60 * 60 * 2// 3 days
   });
 
   var apiForSheets = function(userName, context, isPullRequest) {
@@ -169,7 +169,19 @@ module.exports = (robot) => {
 
   var checkMergeConflicts = function(context) {
     console.log('LIST OF ALL PRs');
-    console.log(context.github.pullRequests.getAll(context.repo()));
+    arrayOfOpenPullRequests = context.github.pullRequests.getAll(context.repo());
+
+    for (var key in arrayOfOpenPullRequests) {
+      pullRequestNumber = arrayOfOpenPullRequests[key].number;
+      //console.log('PULL REQUEST NUMBER');
+      //console.log(pullRequestNumber);
+      pullRequestDetails = context.github.pullRequests.get(context.repo({number: pullRequestNumber}));
+      isMergeable = pullRequestDetails.mergeable;
+      if (!isMergeable) {
+        console.log('MERGE CONFLICT PR');
+        console.log(pullRequestNumber);
+      }
+    }
   };
 
   /*

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 1000 * 24 * 3 // 3 days
+    interval: 60 * 60 * 1000 // 3 days
   });
 
   var pullRequestAuthor;
@@ -177,6 +177,7 @@ module.exports = (robot) => {
   };
 
   var checkMergeConflicts = function(context) {
+    var mergeConflictLabel = ['Has Merge Conflicts'];
     arrayOfOpenPullRequests = (
       context.github.pullRequests.getAll(context.repo()));
     for (var index in arrayOfOpenPullRequests) {
@@ -188,6 +189,20 @@ module.exports = (robot) => {
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');
         console.log(pullRequestNumber);
+
+        const labels = pullRequestDetails.labels;
+        var labelData;
+        var hasMergeConflictLabel = false;
+        labels.then((resp) => {
+          labelData = resp.data;
+          for (var label in labelData) {
+            if (labelData[label].name === mergeConflictLabel[0]) {
+              hasMergeConflictLabel = true;
+              break;
+            }
+          }
+        });
+        break;
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const createScheduler = require('probot-scheduler');
 module.exports = (robot) => {
   scheduler = createScheduler(robot, {
     delay: !process.env.DISABLE_DELAY,
-    interval: 60 * 60 * 2// 3 days
+    interval: 60 * 60 * 15 // 3 days
   });
 
   var apiForSheets = function(userName, context, isPullRequest) {

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ module.exports = (robot) => {
       isMergeable = pullRequestDetails.mergeable;
       if (!isMergeable) {
         console.log('MERGE CONFLICT PR');
-        console.log(pullRequestNumber);
+        console.log(typeof pullRequestNumber);
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,11 @@
+const createScheduler = require('probot-scheduler');
+
 module.exports = (robot) => {
+  scheduler = createScheduler(robot, {
+    delay: !process.env.DISABLE_DELAY,
+    interval: 60 * 60 // 3 days
+  });
+
   var apiForSheets = function(userName, context, isPullRequest) {
     var claLabel = ['Needs CLA'];
     var hasUserSignedCla = false;
@@ -160,10 +167,15 @@ module.exports = (robot) => {
     authorize(JSON.parse(clientSecret), checkClaSheet);
   };
 
+  var checkMergeConflicts = function(context) {
+    console.log('LIST OF ALL PRs');
+    console.log(context.pullRequests.getAll(context.repo()));
+  };
+
   /*
     Please use GitHub Webhook Payloads and not REST APIs.
     Link:  https://octokit.github.io/rest.js/
-  */
+   */
 
   robot.on('issue_comment.created', async context => {
     if (context.isBot === false){
@@ -177,5 +189,9 @@ module.exports = (robot) => {
       const userName = context.payload.pull_request.user.login;
       apiForSheets(userName, context, true);
     }
+  });
+
+  robot.on('schedule.repository', async context => {
+    checkMergeConflicts(context);
   });
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "google-auth-library": "^0.12.0",
     "googleapis": "^25.0.0",
     "probot": "^5.0.0",
+    "probot-scheduler": "^1.2.0",
     "probot-stale": "probot/stale"
   },
   "probot": {


### PR DESCRIPTION
This PR implements a merge conflict check via the Oppia bot.

This check is scheduled to run once in three days presently (can be changed once we put this in place) and checks all open PRs in descending order of the date of creation.

**Action**:
The bot puts in a label "Has Merge Conflicts" on the PR and pings the author of the PR regarding the same.
After the specified time interval (three days), it runs again and removes the above-mentioned label for all open PRs for which the conflicts have been resolved and also performs the usual labelling action alongside.