### PR TITLE
Fix #34: Assigns the corresponding project owner for the first review of a PR and Fix #19: Add check to ensure all PRs have changelog labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ require ('newrelic');
 const createScheduler = require('probot-scheduler');
 const apiForSheetsModule = require('./lib/apiForSheets');
 const checkMergeConflictsModule = require('./lib/checkMergeConflicts');
+const checkPullRequestLabelsModule = require('./lib/checkPullRequestLabels');
 const whitelistedAccounts = (
   (process.env.WHITELISTED_ACCOUNTS || '').toLowerCase().split(','));
 var pullRequestAuthor;
@@ -21,6 +22,13 @@ module.exports = (robot) => {
     // the whitelisted accounts.
     if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
       await apiForSheetsModule.checkClaStatus(context);
+      await checkPullRequestLabelsModule.checkPullRequestLabels(context);
+    }
+  });
+
+  robot.on('pull_request.reopened', async context => {
+    if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
+      await checkPullRequestLabelsModule.checkPullRequestLabels(context);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -22,13 +22,19 @@ module.exports = (robot) => {
     // the whitelisted accounts.
     if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
       await apiForSheetsModule.checkClaStatus(context);
-      await checkPullRequestLabelsModule.checkPullRequestLabels(context);
+      await checkPullRequestLabelsModule.checkChangelogLabel(context);
     }
   });
 
   robot.on('pull_request.reopened', async context => {
     if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
-      await checkPullRequestLabelsModule.checkPullRequestLabels(context);
+      await checkPullRequestLabelsModule.checkChangelogLabel(context);
+    }
+  });
+
+  robot.on('pull_request.labeled', async context => {
+    if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
+      await checkPullRequestLabelsModule.checkProjectLabel(context);
     }
   });
 

--- a/lib/apiForSheets.js
+++ b/lib/apiForSheets.js
@@ -70,8 +70,14 @@ module.exports.generateOutput = async function(rows, prNumber, prDetails) {
     }
 
     // If the PR does not have a CLA label and the author has signed
-    // the CLA, no action is required.
+    // the CLA, welcome the author.
     if (hasUserSignedCla === true) {
+      var commentParams = context.repo({
+        number: prNumber,
+        body: 'Hi! @' + userName + '. Welcome to Oppia! ' +
+            'Thank you for signing the CLA. If you want someone ' +
+            'to review your pull request, please add a project label ' +
+            'and I will assign a reviewer to it. Thanks!'});
       return;
     }
 

--- a/lib/apiForSheets.js
+++ b/lib/apiForSheets.js
@@ -70,15 +70,8 @@ module.exports.generateOutput = async function(rows, prNumber, prDetails) {
     }
 
     // If the PR does not have a CLA label and the author has signed
-    // the CLA, welcome the author.
+    // the CLA, no action is required.
     if (hasUserSignedCla === true) {
-      var commentParams = context.repo({
-        number: prNumber,
-        body: 'Hi! @' + userName + '. Welcome to Oppia! ' +
-            'Thank you for signing the CLA. If you want someone ' +
-            'to review your pull request, please add a project label ' +
-            'and I will assign a reviewer to it. Thanks!'});
-      await context.github.issues.createComment(commentParams);
       return;
     }
 

--- a/lib/apiForSheets.js
+++ b/lib/apiForSheets.js
@@ -78,6 +78,7 @@ module.exports.generateOutput = async function(rows, prNumber, prDetails) {
             'Thank you for signing the CLA. If you want someone ' +
             'to review your pull request, please add a project label ' +
             'and I will assign a reviewer to it. Thanks!'});
+      await context.github.issues.createComment(commentParams);
       return;
     }
 

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -63,16 +63,13 @@ module.exports.checkChangelogLabel = async function(context) {
     return;
   }
 
-  // If no changelog label is found, close the PR.
-  // Ask the author to add the label and re-open it.
-  var stateParams = context.issue({state: 'closed'});
-  await context.github.issues.edit(stateParams);
-
+  // If no changelog label is found, ping the author in the PR
+  // thread and ask him/her to add a label.
   var stateCommentParams = context.issue({body: 'Hi, @' + userName +
-    '. This pull request has been closed since it does not have ' +
-    'a "CHANGELOG: ..." label as mentioned in the PR checkbox list. ' +
-    'Please add this label and re-open the pull request. If you ' +
-    'are unsure of which label to add, please ask the reviewers for ' +
+    '. This pull request does not have a "CHANGELOG: ..." label '+
+    'as mentioned in the PR checkbox list. Please add this label. ' +
+    'PRs without this label will not be merged. If you are unsure ' +
+    'of which label to add, please ask the reviewers for ' +
     'guidance. Thanks!'});
   await context.github.issues.createComment(stateCommentParams);
 }

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -9,8 +9,8 @@ module.exports.checkProjectLabel = async function(context) {
   var userName = pullRequest.user.login;
   var projectLabel;
   var hasProjectLabel = labels.some(function(label) {
-    projectLabel = label.name;
-    return projectLabel.trim().toUpperCase().startsWith('PROJECT');
+    projectLabel = label.name.trim();
+    return projectLabel.toUpperCase().startsWith('PROJECT');
   });
 
   // If the PR has a project label, assign the project owner

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -15,7 +15,7 @@ module.exports.checkPullRequestLabels = async function(context) {
 
   // If the PR has a project owner label, assign the project owner
   // for the first-pass review of the PR and leave a top-level comment.
-  if(hasProjectOwnerLabel) {
+  if (hasProjectOwnerLabel) {
     var labelSubstrings = projectOwnerLabel.split('@');
     var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
 
@@ -35,9 +35,9 @@ module.exports.checkPullRequestLabels = async function(context) {
 
   var gitter = 'Gitter', gitterLink = gitter.link('https://gitter.im/oppia/oppia-chat');
   var stateCommentParams = context.issue({body: 'Hi, @' + userName +
-    '. This pull request has been closed since it does have a project ' +
-    'label. Please add this label and re-open the pull request. ' +
-    'If you are unsure about the project label, please feel free to ask ' +
-    'on ' + gitterLink + '. Thanks!'});
+    '. This pull request has been closed since it does not have a project ' +
+    'label as mentioned in the PR checkbox list. Please add this label ' +
+    'and re-open the pull request. If you are unsure about the project ' +
+    'label, please feel free to ask on ' + gitterLink + '. Thanks!'});
   await context.github.issues.createComment(stateCommentParams);
 }

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -1,0 +1,41 @@
+module.exports.checkPullRequestLabels = function(context) {
+    var pullRequest = context.payload.pull_request;
+    var pullRequestNumber = pullRequest.number;
+
+    // eslint-disable-next-line no-console
+    console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
+
+    var labels = pullRequest.labels;
+    var userName = pullRequest.user.login;
+    var projectOwnerLabel;
+    var hasProjectOwnerLabel = labels.some(function(label) {
+        projectOwnerLabel = label;
+        return label.startsWith('PROJECT');
+    });
+
+    // If the PR has a project owner label, assign the project owner
+    // for the first-pass review of the PR and leave a top-level comment.
+    if(hasProjectOwnerLabel === true) {
+        var labelSubstrings = projectOwnerLabel.split('@');
+        var projectOwner = labelSubstrings[labelSubstrings.length-1].trim();
+        var PRAssignees = [projectOwner];
+
+        var assigneeParams = context.issues({assignees: PRAssignees});
+        await context.github.issues.addAssignees(assigneeParams);
+
+        var commentParams = context.issues({body: 'Assigning @' + projectOwner +
+            ' for the first-pass review of this pull request. Thanks!'});
+        await context.github.issues.createComment(commentParams);
+        return;
+    }
+
+    // If no project owner label is found, close the PR.
+    // Ask the author to add the label and re-open it.
+    var stateParams = context.issues({state: 'closed'});
+    await context.github.issues.edit({stateParams});
+
+    var stateCommentParams = context.issues({body: 'Hi, @' + userName +
+        '. This pull request has been closed since it does have a project ' +
+        'owner label. Please add this label and re-open the pull request.'});
+    await context.github.issues.createComment(stateCommentParams);
+}

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -1,34 +1,52 @@
-module.exports.checkPullRequestLabels = async function(context) {
+module.exports.checkProjectLabel = async function(context) {
   var pullRequest = context.payload.pull_request;
   var pullRequestNumber = pullRequest.number;
 
   // eslint-disable-next-line no-console
-  console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
+  console.log('RUNNING PROJECT LABEL CHECK ON PULL REQUEST ' + pullRequestNumber + ' ...');
 
   var labels = pullRequest.labels;
   var userName = pullRequest.user.login;
-  var projectOwnerLabel;
-  var hasProjectOwnerLabel = labels.some(function(label) {
-    projectOwnerLabel = label.name;
-    return projectOwnerLabel.startsWith('PROJECT');
+  var projectLabel;
+  var hasProjectLabel = labels.some(function(label) {
+    projectLabel = label.name;
+    return projectLabel.trim().toUpperCase().startsWith('PROJECT');
   });
 
-  // If the PR has a project owner label, assign the project owner
+  // If the PR has a project label, assign the project owner
   // for the first-pass review of the PR and leave a top-level comment.
-  if (hasProjectOwnerLabel) {
-    var labelSubstrings = projectOwnerLabel.split('@');
-    var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
+  if (hasProjectLabel) {
+    // Check if project label is valid.
 
-    var assigneeParams = context.issue({assignees: [projectOwner]});
-    await context.github.issues.addAssigneesToIssue(assigneeParams);
+    // Please refer to https://regex101.com/r/IRWeSA/1 for explanation
+    // of the below regular expression.
+    var regExpForProjectLabel = /^([pP][rR][oO][jJ][eE][cC][tT].*@\s*\w+\s*)/;
+    var isProjectLabelValid = regExpForProjectLabel.test(projectLabel);
 
-    var commentParams = context.issue({body: 'Assigning @' + projectOwner +
-      ' for the first-pass review of this pull request. Thanks!'});
-    await context.github.issues.createComment(commentParams);
+    if (isProjectLabelValid) {
+      var labelSubstrings = projectLabel.split('@');
+      var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
+
+      var assigneeParams = context.issue({assignees: [projectOwner]});
+      await context.github.issues.addAssigneesToIssue(assigneeParams);
+
+      var commentParams = context.issue({body: 'Assigning @' + projectOwner +
+        ' for the first-pass review of this pull request. Thanks!'});
+      await context.github.issues.createComment(commentParams);
+    }
+    else {
+      // There is some problem with the project label. Ping the dev workflow team
+      // in a comment on the PR.
+      var failedCommentParams = context.issue({body: 'Hi, @oppia/dev-workflow-team.' +
+      ' The project label on this pull request seems to be invalid.' +
+      ' Can you please take a look at this pull request? Thanks!'});
+      await context.github.issues.createComment(failedCommentParams);
+    }
+
     return;
   }
 
-  // If no project owner label is found, close the PR.
+  // If no project label is found, close the PR.
   // Ask the author to add the label and re-open it.
   var stateParams = context.issue({state: 'closed'});
   await context.github.issues.edit(stateParams);
@@ -40,4 +58,45 @@ module.exports.checkPullRequestLabels = async function(context) {
     'and re-open the pull request. If you are unsure about the project ' +
     'label, please feel free to ask on ' + gitterLink + '. Thanks!'});
   await context.github.issues.createComment(stateCommentParams);
+}
+
+module.exports.checkChangelogLabel = async function(context) {
+  var pullRequest = context.payload.pull_request;
+  var pullRequestNumber = pullRequest.number;
+
+  // eslint-disable-next-line no-console
+  console.log('RUNNING CHANGELOG LABEL CHECK ON PULL REQUEST ' + pullRequestNumber + ' ...');
+
+  var labels = pullRequest.labels;
+  var userName = pullRequest.user.login;
+  var hasChangelogLabel = labels.some(function(label) {
+    return label.name.trim().toUpperCase().startsWith('CHANGELOG');
+  });
+
+  // If the PR has a changelog label, no action is required.
+  if(hasChangelogLabel) return;
+
+  // If no changelog label is found, close the PR.
+  // Ask the author to add the label and re-open it.
+  var stateParams = context.issue({state: 'closed'});
+  await context.github.issues.edit(stateParams);
+
+  var stateCommentParams = context.issue({body: 'Hi, @' + userName +
+    '. This pull request has been closed since it does not have ' +
+    'a "CHANGELOG: ..." label as mentioned in the PR checkbox list. ' +
+    'Please add this label and re-open the pull request. If you ' +
+    'are unsure of which label to add, please ask the reviewers for ' +
+    'guidance. Thanks!'});
+  await context.github.issues.createComment(stateCommentParams);
+}
+
+module.exports.checkPullRequestLabels = async function(context) {
+  var pullRequest = context.payload.pull_request;
+  var pullRequestNumber = pullRequest.number;
+
+  // eslint-disable-next-line no-console
+  console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
+
+  this.checkProjectLabel(context);
+  this.checkChangelogLabel(context);
 }

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -15,7 +15,7 @@ module.exports.checkPullRequestLabels = async function(context) {
 
   // If the PR has a project owner label, assign the project owner
   // for the first-pass review of the PR and leave a top-level comment.
-  if(hasProjectOwnerLabel === true) {
+  if(hasProjectOwnerLabel) {
     var labelSubstrings = projectOwnerLabel.split('@');
     var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
 

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -1,4 +1,4 @@
-module.exports.checkPullRequestLabels = function(context) {
+module.exports.checkPullRequestLabels = async function(context) {
   var pullRequest = context.payload.pull_request;
   var pullRequestNumber = pullRequest.number;
 
@@ -9,8 +9,8 @@ module.exports.checkPullRequestLabels = function(context) {
   var userName = pullRequest.user.login;
   var projectOwnerLabel;
   var hasProjectOwnerLabel = labels.some(function(label) {
-    projectOwnerLabel = label;
-    return label.startsWith('PROJECT');
+    projectOwnerLabel = label.name;
+    return projectOwnerLabel.startsWith('PROJECT');
   });
 
   // If the PR has a project owner label, assign the project owner
@@ -18,12 +18,11 @@ module.exports.checkPullRequestLabels = function(context) {
   if(hasProjectOwnerLabel === true) {
     var labelSubstrings = projectOwnerLabel.split('@');
     var projectOwner = labelSubstrings[labelSubstrings.length-1].trim();
-    var PRAssignees = [projectOwner];
 
-    var assigneeParams = context.issues({assignees: PRAssignees});
-    await context.github.issues.addAssignees(assigneeParams);
+    var assigneeParams = context.issue({assignees: [projectOwner]});
+    await context.github.issues.addAssigneesToIssue(assigneeParams);
 
-    var commentParams = context.issues({body: 'Assigning @' + projectOwner +
+    var commentParams = context.issue({body: 'Assigning @' + projectOwner +
       ' for the first-pass review of this pull request. Thanks!'});
     await context.github.issues.createComment(commentParams);
     return;
@@ -31,10 +30,10 @@ module.exports.checkPullRequestLabels = function(context) {
 
   // If no project owner label is found, close the PR.
   // Ask the author to add the label and re-open it.
-  var stateParams = context.issues({state: 'closed'});
-  await context.github.issues.edit({stateParams});
+  var stateParams = context.issue({state: 'closed'});
+  await context.github.issues.edit(stateParams);
 
-  var stateCommentParams = context.issues({body: 'Hi, @' + userName +
+  var stateCommentParams = context.issue({body: 'Hi, @' + userName +
     '. This pull request has been closed since it does have a project ' +
     'owner label. Please add this label and re-open the pull request.'});
   await context.github.issues.createComment(stateCommentParams);

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -17,7 +17,7 @@ module.exports.checkPullRequestLabels = async function(context) {
   // for the first-pass review of the PR and leave a top-level comment.
   if(hasProjectOwnerLabel === true) {
     var labelSubstrings = projectOwnerLabel.split('@');
-    var projectOwner = labelSubstrings[labelSubstrings.length-1].trim();
+    var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
 
     var assigneeParams = context.issue({assignees: [projectOwner]});
     await context.github.issues.addAssigneesToIssue(assigneeParams);
@@ -33,8 +33,11 @@ module.exports.checkPullRequestLabels = async function(context) {
   var stateParams = context.issue({state: 'closed'});
   await context.github.issues.edit(stateParams);
 
+  var gitter = 'Gitter', gitterLink = gitter.link('https://gitter.im/oppia/oppia-chat');
   var stateCommentParams = context.issue({body: 'Hi, @' + userName +
     '. This pull request has been closed since it does have a project ' +
-    'owner label. Please add this label and re-open the pull request.'});
+    'label. Please add this label and re-open the pull request. ' +
+    'If you are unsure about the project label, please feel free to ask ' +
+    'on ' + gitterLink + '. Thanks!'});
   await context.github.issues.createComment(stateCommentParams);
 }

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -6,7 +6,7 @@ module.exports.checkProjectLabel = async function(context) {
   console.log('RUNNING PROJECT LABEL CHECK ON PULL REQUEST ' +
     pullRequestNumber + ' ...');
 
-  var projectLabel = pullRequest.label.name.trim();
+  var projectLabel = context.payload.label.name.trim();
   var hasProjectLabel = projectLabel.toUpperCase().startsWith('PROJECT');
 
   // If the PR has a project label, assign the project owner

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -1,41 +1,41 @@
 module.exports.checkPullRequestLabels = function(context) {
-    var pullRequest = context.payload.pull_request;
-    var pullRequestNumber = pullRequest.number;
+  var pullRequest = context.payload.pull_request;
+  var pullRequestNumber = pullRequest.number;
 
-    // eslint-disable-next-line no-console
-    console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
+  // eslint-disable-next-line no-console
+  console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
 
-    var labels = pullRequest.labels;
-    var userName = pullRequest.user.login;
-    var projectOwnerLabel;
-    var hasProjectOwnerLabel = labels.some(function(label) {
-        projectOwnerLabel = label;
-        return label.startsWith('PROJECT');
-    });
+  var labels = pullRequest.labels;
+  var userName = pullRequest.user.login;
+  var projectOwnerLabel;
+  var hasProjectOwnerLabel = labels.some(function(label) {
+    projectOwnerLabel = label;
+    return label.startsWith('PROJECT');
+  });
 
-    // If the PR has a project owner label, assign the project owner
-    // for the first-pass review of the PR and leave a top-level comment.
-    if(hasProjectOwnerLabel === true) {
-        var labelSubstrings = projectOwnerLabel.split('@');
-        var projectOwner = labelSubstrings[labelSubstrings.length-1].trim();
-        var PRAssignees = [projectOwner];
+  // If the PR has a project owner label, assign the project owner
+  // for the first-pass review of the PR and leave a top-level comment.
+  if(hasProjectOwnerLabel === true) {
+    var labelSubstrings = projectOwnerLabel.split('@');
+    var projectOwner = labelSubstrings[labelSubstrings.length-1].trim();
+    var PRAssignees = [projectOwner];
 
-        var assigneeParams = context.issues({assignees: PRAssignees});
-        await context.github.issues.addAssignees(assigneeParams);
+    var assigneeParams = context.issues({assignees: PRAssignees});
+    await context.github.issues.addAssignees(assigneeParams);
 
-        var commentParams = context.issues({body: 'Assigning @' + projectOwner +
-            ' for the first-pass review of this pull request. Thanks!'});
-        await context.github.issues.createComment(commentParams);
-        return;
-    }
+    var commentParams = context.issues({body: 'Assigning @' + projectOwner +
+      ' for the first-pass review of this pull request. Thanks!'});
+    await context.github.issues.createComment(commentParams);
+    return;
+  }
 
-    // If no project owner label is found, close the PR.
-    // Ask the author to add the label and re-open it.
-    var stateParams = context.issues({state: 'closed'});
-    await context.github.issues.edit({stateParams});
+  // If no project owner label is found, close the PR.
+  // Ask the author to add the label and re-open it.
+  var stateParams = context.issues({state: 'closed'});
+  await context.github.issues.edit({stateParams});
 
-    var stateCommentParams = context.issues({body: 'Hi, @' + userName +
-        '. This pull request has been closed since it does have a project ' +
-        'owner label. Please add this label and re-open the pull request.'});
-    await context.github.issues.createComment(stateCommentParams);
+  var stateCommentParams = context.issues({body: 'Hi, @' + userName +
+    '. This pull request has been closed since it does have a project ' +
+    'owner label. Please add this label and re-open the pull request.'});
+  await context.github.issues.createComment(stateCommentParams);
 }

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -3,7 +3,8 @@ module.exports.checkProjectLabel = async function(context) {
   var pullRequestNumber = pullRequest.number;
 
   // eslint-disable-next-line no-console
-  console.log('RUNNING PROJECT LABEL CHECK ON PULL REQUEST ' + pullRequestNumber + ' ...');
+  console.log('RUNNING PROJECT LABEL CHECK ON PULL REQUEST ' +
+    pullRequestNumber + ' ...');
 
   var labels = pullRequest.labels;
   var userName = pullRequest.user.login;
@@ -21,9 +22,9 @@ module.exports.checkProjectLabel = async function(context) {
     // Please refer to https://regex101.com/r/IRWeSA/1 for explanation
     // of the below regular expression.
     var regExpForProjectLabel = /^([pP][rR][oO][jJ][eE][cC][tT].*@\s*\w+\s*)/;
-    var isProjectLabelValid = regExpForProjectLabel.test(projectLabel);
+    var projectLabelIsValid = regExpForProjectLabel.test(projectLabel);
 
-    if (isProjectLabelValid) {
+    if (projectLabelIsValid) {
       var labelSubstrings = projectLabel.split('@');
       var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
 
@@ -33,8 +34,7 @@ module.exports.checkProjectLabel = async function(context) {
       var commentParams = context.issue({body: 'Assigning @' + projectOwner +
         ' for the first-pass review of this pull request. Thanks!'});
       await context.github.issues.createComment(commentParams);
-    }
-    else {
+    } else {
       // There is some problem with the project label. Ping the dev workflow team
       // in a comment on the PR.
       var failedCommentParams = context.issue({body: 'Hi, @oppia/dev-workflow-team.' +
@@ -65,7 +65,8 @@ module.exports.checkChangelogLabel = async function(context) {
   var pullRequestNumber = pullRequest.number;
 
   // eslint-disable-next-line no-console
-  console.log('RUNNING CHANGELOG LABEL CHECK ON PULL REQUEST ' + pullRequestNumber + ' ...');
+  console.log('RUNNING CHANGELOG LABEL CHECK ON PULL REQUEST ' +
+    pullRequestNumber + ' ...');
 
   var labels = pullRequest.labels;
   var userName = pullRequest.user.login;
@@ -74,7 +75,9 @@ module.exports.checkChangelogLabel = async function(context) {
   });
 
   // If the PR has a changelog label, no action is required.
-  if(hasChangelogLabel) return;
+  if (hasChangelogLabel) {
+    return;
+  }
 
   // If no changelog label is found, close the PR.
   // Ask the author to add the label and re-open it.

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -6,13 +6,8 @@ module.exports.checkProjectLabel = async function(context) {
   console.log('RUNNING PROJECT LABEL CHECK ON PULL REQUEST ' +
     pullRequestNumber + ' ...');
 
-  var labels = pullRequest.labels;
-  var userName = pullRequest.user.login;
-  var projectLabel;
-  var hasProjectLabel = labels.some(function(label) {
-    projectLabel = label.name.trim();
-    return projectLabel.toUpperCase().startsWith('PROJECT');
-  });
+  var projectLabel = pullRequest.label.name.trim();
+  var hasProjectLabel = projectLabel.toUpperCase().startsWith('PROJECT');
 
   // If the PR has a project label, assign the project owner
   // for the first-pass review of the PR and leave a top-level comment.
@@ -46,18 +41,7 @@ module.exports.checkProjectLabel = async function(context) {
     return;
   }
 
-  // If no project label is found, close the PR.
-  // Ask the author to add the label and re-open it.
-  var stateParams = context.issue({state: 'closed'});
-  await context.github.issues.edit(stateParams);
-
-  var gitter = 'Gitter', gitterLink = gitter.link('https://gitter.im/oppia/oppia-chat');
-  var stateCommentParams = context.issue({body: 'Hi, @' + userName +
-    '. This pull request has been closed since it does not have a project ' +
-    'label as mentioned in the PR checkbox list. Please add this label ' +
-    'and re-open the pull request. If you are unsure about the project ' +
-    'label, please feel free to ask on ' + gitterLink + '. Thanks!'});
-  await context.github.issues.createComment(stateCommentParams);
+  // If no project label is found, no action is required.
 }
 
 module.exports.checkChangelogLabel = async function(context) {
@@ -91,15 +75,4 @@ module.exports.checkChangelogLabel = async function(context) {
     'are unsure of which label to add, please ask the reviewers for ' +
     'guidance. Thanks!'});
   await context.github.issues.createComment(stateCommentParams);
-}
-
-module.exports.checkPullRequestLabels = async function(context) {
-  var pullRequest = context.payload.pull_request;
-  var pullRequestNumber = pullRequest.number;
-
-  // eslint-disable-next-line no-console
-  console.log('RUNNING LABEL CHECKS ON PULL REQUEST ' + pullRequestNumber + ' ...');
-
-  this.checkProjectLabel(context);
-  this.checkChangelogLabel(context);
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #34: Assigns the corresponding project owner for the first review of a PR once a project label is found. If no project label is found, the bot will close the PR with a message to add a project label to the author.

Fixes #19: Adds check to ensure that all PRs have changelog labels. If a PR does not have a changelog label, close the PR with a comment addressed to the author to add the label.

How the checks will function:

![screenshot-lh3 googleusercontent com-2019 07 27-02-03-38](https://user-images.githubusercontent.com/24826041/61980010-09651f00-b013-11e9-9198-b836c2802bf4.png)



~Please note that the project labels need to be modified as discussed (@DubeySandeep is working on it) before this check is deployed.~ (Sandeep has done this. Thanks, Sandeep!)

## Checklist
- [X] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [X] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
