### PR TITLE
Fix over eager assignments 

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (robot) => {
 
   robot.on('pull_request.labeled', async context => {
     if (whitelistedAccounts.includes(context.repo().owner.toLowerCase())) {
-      await checkPullRequestLabelsModule.checkChangelogLabel(context);
+      await checkPullRequestLabelsModule.checkAssignee(context);
     }
   });
 

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -1,3 +1,47 @@
+var matchChangelogLabelWithRegex = function(changelogLabel) {
+  // Please refer to https://regex101.com/r/Eo976S/2 for explanation
+  // of the below regular expression.
+  var regExpForChangelogLabel = (
+    /^([cC][hH][aA][nN][gG][eE][lL][oO][gG]: .* -- @\s*\w+\s*)/);
+  return regExpForChangelogLabel.test(changelogLabel);
+}
+
+module.exports.checkAssignee = async function(context) {
+  var pullRequest = context.payload.pull_request;
+  var pullRequestNumber = pullRequest.number;
+
+  // eslint-disable-next-line no-console
+  console.log('RUNNING ASSIGNEE CHECK ON PULL REQUEST ' +
+    pullRequestNumber + ' ...');
+
+  var changelogLabel = context.payload.label.name.trim();
+  var hasChangelogLabel = changelogLabel.toUpperCase().startsWith('CHANGELOG');
+
+  // If the PR has a changelog label, assign the project owner
+  // for the first-pass review of the PR and leave a top-level comment.
+  if (hasChangelogLabel) {
+    var changelogLabelIsValid = matchChangelogLabelWithRegex(changelogLabel);
+    if (!changelogLabelIsValid) {
+      // No action is taken here since a comment is already added initially
+      // for invalid labels when a pull request is opened.
+      return;
+    }
+    var labelSubstrings = changelogLabel.split('@');
+    var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
+
+    if (projectOwner !== pullRequest.user.login) {
+      var assigneeParams = context.issue({assignees: [projectOwner]});
+      await context.github.issues.addAssigneesToIssue(assigneeParams);
+
+      var commentParams = context.issue({body: 'Assigning @' + projectOwner +
+        ' for the first-pass review of this pull request. Thanks!'});
+      await context.github.issues.createComment(commentParams);
+    }
+    return;
+  }
+  // If no changelog label is found, no action is required.
+}
+
 module.exports.checkChangelogLabel = async function(context) {
   var pullRequest = context.payload.pull_request;
   var pullRequestNumber = pullRequest.number;
@@ -18,25 +62,8 @@ module.exports.checkChangelogLabel = async function(context) {
 
   // If the PR has a changelog label, no action is required.
   if (hasChangelogLabel) {
-    // Please refer to https://regex101.com/r/Eo976S/2 for explanation
-    // of the below regular expression.
-    var regExpForChangelogLabel = (
-      /^([cC][hH][aA][nN][gG][eE][lL][oO][gG]: .* -- @\s*\w+\s*)/);
-    var changelogLabelIsValid = regExpForChangelogLabel.test(changelogLabel);
-
-    if (changelogLabelIsValid) {
-      var labelSubstrings = changelogLabel.split('@');
-      var projectOwner = labelSubstrings[labelSubstrings.length - 1].trim();
-
-      if (projectOwner !== pullRequest.user.login) {
-        var assigneeParams = context.issue({assignees: [projectOwner]});
-        await context.github.issues.addAssigneesToIssue(assigneeParams);
-
-        var commentParams = context.issue({body: 'Assigning @' + projectOwner +
-          ' for the first-pass review of this pull request. Thanks!'});
-        await context.github.issues.createComment(commentParams);
-      }
-    } else {
+    var changelogLabelIsValid = matchChangelogLabelWithRegex(changelogLabel);
+    if (!changelogLabelIsValid) {
       // There is some problem with the changelog label. Ping the dev workflow team
       // in a comment on the PR.
       var failedCommentParams = context.issue({body: 'Hi, @oppia/dev-workflow-team.' +


### PR DESCRIPTION
## Explanation
Fixes over eager notifications by Oppiabot by adding a separate check to assign project owners.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
