### PR TITLE
Fix over eager assignments when a review is already done

### DIFF
--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -8,6 +8,12 @@ var matchChangelogLabelWithRegex = function(changelogLabel) {
 
 module.exports.checkAssignee = async function(context) {
   var pullRequest = context.payload.pull_request;
+
+  if (pull_request.review_comments !== 0) {
+    // We do not assign anyone to the pull request in this case since
+    // a review is already done.
+    return;
+  }
   var pullRequestNumber = pullRequest.number;
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## Explanation
Updates assignee check to avoid assignment from changelog label when a review is already done on the PR.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).

I was not able to test the above - my oppiabot setup works fine but it is not being triggered on merge conflicts (on master branch as well). This change should be safe from the perspective of tests on manual tests matrix since it isn't directly/indirectly affecting any code related to that.
