### PR TITLE
Fix #90: Use actual job name in comment

### DIFF
--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -129,11 +129,11 @@ const getRegistryReminder = (newJobFiles, changedFiles) => {
   );
 
   if (hasNotAddedFileToRegistry) {
-    const fileText = newJobFiles.length > 1 ? 'files' : 'file';
+    const jobText = newJobFiles.length > 1 ? 'jobs' : 'job';
     const jobRegistryFile = 'job registry'.link(
       'https://github.com/oppia/oppia/blob/develop/core/jobs_registry.py');
     registryReminder +=
-      'please add the new job ' + fileText + ' to the '+ jobRegistryFile +' and ';
+      'please add the new ' + jobText + ' to the '+ jobRegistryFile +' and ';
   }
 
   return registryReminder;

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -2,6 +2,7 @@ const { SERVER_JOBS_ADMIN } = require('../userWhitelist.json');
 const REGISTRY_FILENAME = 'jobs_registry.py';
 const JOB_FILE_FIX = '_jobs_';
 const CRITICAL_LABEL = 'critical';
+const TEST_DIR_PREFIX = 'core/tests/';
 
 /**
  * @param {import('probot').Octokit.PullsListFilesResponseItem}
@@ -14,7 +15,7 @@ const isJobFile = ({ filename }) => {
  * @param {string} filename
  */
 const isInTestDir = (filename) => {
-  return filename.startsWith('core/tests/');
+  return filename.startsWith(TEST_DIR_PREFIX);
 }
 
 /**

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -54,10 +54,10 @@ const addsNewJob = (file) => {
  * @param {string} filename
  *
  * @example
- * getJobNameFromFileName('core/domain/user_jobs_one_off.py')
+ * getJobModuleName('core/domain/user_jobs_one_off.py')
  * // returns user_jobs_one_off
  */
-const getJobNameFromFileName = (filename) => {
+const getJobModuleName = (filename) => {
   // Filename is the relative path to the file, we need to
   // get the exact file name.
   const substrings = filename.split('/');
@@ -122,9 +122,9 @@ const getRegistryReminder = (newJobFiles, changedFiles) => {
   const hasNotAddedFileToRegistry = newJobFiles.some(
     (file) => {
       const jobs = getNewJobsFromFile(file);
-      const jobName = getJobNameFromFileName(file.filename);
+      const jobModuleName = getJobModuleName(file.filename);
       return jobs.some((job) => !isRegistryUpdated(
-        `${jobName}.${job}`, changedFiles ));
+        `${jobModuleName}.${job}`, changedFiles ));
     }
   );
 

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -50,7 +50,7 @@ const addsNewJob = (file) => {
 };
 
 /**
- * Returns the name of the job from it's file name.
+ * Returns the name of the job module from it's file name.
  * @param {string} filename
  *
  * @example

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -7,8 +7,15 @@ const CRITICAL_LABEL = 'critical';
  * @param {import('probot').Octokit.PullsListFilesResponseItem}
  */
 const isJobFile = ({ filename }) => {
-  return filename.includes(JOB_FILE_FIX);
+  return filename.includes(JOB_FILE_FIX) && !isInTestDir(filename);
 };
+
+/**
+ * @param {string} filename
+ */
+const isInTestDir = (filename) => {
+  return filename.startsWith('core/tests/');
+}
 
 /**
  * @param {import('probot').Octokit.PullsListFilesResponseItem}
@@ -144,11 +151,15 @@ const getRegistryReminder = (newJobFiles, changedFiles) => {
  */
 const getJobNameString = (newJobFiles) => {
   let jobNameString = '';
-  let jobNameArray = newJobFiles.map(file => getNewJobsFromFile(file));
-  const flattened = arr => [].concat(...arr);
-  jobNameArray = flattened(jobNameArray);
+  let totalNumberOfJobs = 0;
 
-  if (jobNameArray.length === 1) {
+  let jobNameArray = newJobFiles.map(file => {
+    const newJobNames = getNewJobsFromFile(file);
+    totalNumberOfJobs += newJobNames.length;
+    return (newJobNames.join(', ')).link(file.blob_url);
+  });
+
+  if (totalNumberOfJobs === 1) {
     jobNameString = ' The name of the job is ' + jobNameArray[0] + '.';
   } else {
     jobNameString = ' The jobs are ' + jobNameArray.join(', ') + '.';

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -144,9 +144,10 @@ const getRegistryReminder = (newJobFiles, changedFiles) => {
  */
 const getJobNameString = (newJobFiles) => {
   let jobNameString = '';
-  const jobNameArray = newJobFiles.map((file) =>
-    getJobNameFromFileName(file.filename)
-  );
+  let jobNameArray = newJobFiles.map(file => getNewJobsFromFile(file));
+  const flattened = arr => [].concat(...arr);
+  jobNameArray = flattened(jobNameArray);
+
   if (jobNameArray.length === 1) {
     jobNameString = ' The name of the job is ' + jobNameArray[0] + '.';
   } else {

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -179,7 +179,7 @@ describe('Pull Request Job Spec', () => {
       expect(github.issues.createComment).toHaveBeenCalledWith({
         issue_number: payloadData.payload.pull_request.number,
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
-        'it adds a new one off job. The name of the job is exp_jobs_one_off.' +
+        'it adds a new one off job. The name of the job is FirstTestOneOffJob.' +
         newLineFeed + 'Also @' + author + ', please add the new job ' +
         'file to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
         formText + ' for the new job to be tested on the backup server. ' +
@@ -253,7 +253,7 @@ describe('Pull Request Job Spec', () => {
       expect(github.issues.createComment).toHaveBeenCalledWith({
         issue_number: payloadData.payload.pull_request.number,
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
-        'it adds new one off jobs. The jobs are exp_jobs_one_off, exp_jobs_oppiabot_off.' +
+        'it adds new one off jobs. The jobs are FirstTestOneOffJob, SecondTestOneOffJob.' +
         newLineFeed + 'Also @' + author + ', please add the new job ' +
         'files to the '+ jobRegistryLink +' and please make sure to fill in the ' +
         formText + ' for the new jobs to be tested on the backup server. ' +
@@ -325,7 +325,7 @@ describe('Pull Request Job Spec', () => {
         expect(github.issues.createComment).toHaveBeenCalledWith({
           issue_number: payloadData.payload.pull_request.number,
           body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
-          'it adds a new one off job. The name of the job is exp_jobs_one_off.' +
+          'it adds a new one off job. The name of the job is FirstTestOneOffJob.' +
           newLineFeed + 'Also @' + author + ', please make sure to fill in the ' +
           formText + ' for the new job to be tested on the backup server. ' +
           'This PR can be merged only after the test run is successful. ' +
@@ -395,7 +395,7 @@ describe('Pull Request Job Spec', () => {
       expect(github.issues.createComment).toHaveBeenCalledWith({
         issue_number: payloadData.payload.pull_request.number,
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
-        'it adds a new one off job. The name of the job is user_jobs_one_off.' +
+        'it adds a new one off job. The name of the job is OppiabotContributionsOneOffJob.' +
         newLineFeed + 'Also @' + author + ', please add the new job ' +
         'file to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
         formText + ' for the new job to be tested on the backup server. ' +

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -181,7 +181,7 @@ describe('Pull Request Job Spec', () => {
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
         'it adds a new one off job. The name of the job is FirstTestOneOffJob.' +
         newLineFeed + 'Also @' + author + ', please add the new job ' +
-        'file to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
+        'to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
         formText + ' for the new job to be tested on the backup server. ' +
         'This PR can be merged only after the test run is successful. ' +
         'Please refer to ' + wikiLinkText + ' for details.' + newLineFeed + 'Thanks!',
@@ -254,8 +254,8 @@ describe('Pull Request Job Spec', () => {
         issue_number: payloadData.payload.pull_request.number,
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
         'it adds new one off jobs. The jobs are FirstTestOneOffJob, SecondTestOneOffJob.' +
-        newLineFeed + 'Also @' + author + ', please add the new job ' +
-        'files to the '+ jobRegistryLink +' and please make sure to fill in the ' +
+        newLineFeed + 'Also @' + author + ', please add the new jobs ' +
+        'to the '+ jobRegistryLink +' and please make sure to fill in the ' +
         formText + ' for the new jobs to be tested on the backup server. ' +
         'This PR can be merged only after the test run is successful. ' +
         'Please refer to ' + wikiLinkText + ' for details.' + newLineFeed + 'Thanks!',
@@ -397,7 +397,7 @@ describe('Pull Request Job Spec', () => {
         body: 'Hi @' + SERVER_JOBS_ADMIN + ', PTAL at this PR, ' +
         'it adds a new one off job. The name of the job is OppiabotContributionsOneOffJob.' +
         newLineFeed + 'Also @' + author + ', please add the new job ' +
-        'file to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
+        'to the ' + jobRegistryLink + ' and please make sure to fill in the ' +
         formText + ' for the new job to be tested on the backup server. ' +
         'This PR can be merged only after the test run is successful. ' +
         'Please refer to ' + wikiLinkText + ' for details.' + newLineFeed + 'Thanks!',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #90 by pinging the server jobs admin with the actual job that got added and not the job module.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
