### PR TITLE
Prevent Oppiabot from checking job tests

### DIFF
--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -1,15 +1,7 @@
 const { SERVER_JOBS_ADMIN } = require('../userWhitelist.json');
 const REGISTRY_FILENAME = 'jobs_registry.py';
-const JOB_FILE_FIX = '_jobs_';
 const CRITICAL_LABEL = 'critical';
 const TEST_DIR_PREFIX = 'core/tests/';
-
-/**
- * @param {import('probot').Octokit.PullsListFilesResponseItem}
- */
-const isJobFile = ({ filename }) => {
-  return filename.includes(JOB_FILE_FIX) && !isInTestDir(filename);
-};
 
 /**
  * @param {string} filename
@@ -17,13 +9,6 @@ const isJobFile = ({ filename }) => {
 const isInTestDir = (filename) => {
   return filename.startsWith(TEST_DIR_PREFIX);
 }
-
-/**
- * @param {import('probot').Octokit.PullsListFilesResponseItem}
- */
-const isNewFile = ({ status }) => {
-  return status === 'added';
-};
 
 /**
  * @param {import('probot').Octokit.PullsListFilesResponseItem} file
@@ -237,7 +222,7 @@ const checkForNewJob = async (context) => {
 
     // Get new jobs that were created in the PR.
     const newJobFiles = changedFiles.filter((file) => {
-      return isJobFile(file) && (isNewFile(file) || addsNewJob(file));
+      return !isInTestDir(file.filename) && addsNewJob(file);
     });
 
     if (newJobFiles.length > 0) {

--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -34,7 +34,7 @@ const getNewJobsFromFile = (file) => {
   // '+' represents an addition while '-' represents a deletion.
   const newLineAdded = '\n+';
   const changesArray = file.patch.split(newLineAdded);
-  const jobRegex = /(?<classDefinition>class\s)(?<jobName>[a-zA-Z]{2,256})(?<jobSuffix>OneOffJob)/;
+  const jobRegex = /(?<classDefinition>class\s)(?<jobName>[a-zA-Z]{2,256})(?<jobSuffix>OneOffJob)(?<funDef>\()/;
 
   const newJobDefinitions = changesArray.filter(change => {
     const matches = jobRegex.exec(change);

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -112,6 +112,22 @@ describe('Pull Request Job Spec', () => {
     patch: '@@ -0,0 +1 @@\n+class TestOneOffJob(jobs.BaseMapReduceOneOffJobManager):\n+    """One-off job for creating and populating UserContributionsModels for \n+class AnotherTestOneOffJob(jobs.BaseMapReduceOneOffJobManager):\n+    """\n+    @classmethod\n+    def entity_classes_to_map_over(cls):\n+        """Return a list of datastore class references to map over."""\n+        return [exp_models.ExplorationSnapshotMetadataModel]\n+\n+    @staticmethod\n+    def map(item):\n+        """Implements the map function for this job."""\n+        yield (\n+            item.committer_id, {\n+                \'exploration_id\': item.get_unversioned_instance_id(),\n+                \'version_string\': item.get_version_string(),\n+            })\n+\n+\n+    @staticmethod\n+    def reduce(key, version_and_exp_ids):\n+        """Implements the reduce function for this job."""\n+        created_exploration_ids = set()\n+        edited_exploration_ids = set()\n+\n+        edits = [ast.literal_eval(v) for v in version_and_exp_ids]\n+\n+        for edit in edits:\n+            edited_exploration_ids.add(edit[\'exploration_id\'])\n+            if edit[\'version_string\'] == \'1\':\n+                created_exploration_ids.add(edit[\'exploration_id\'])\n+\n+        if user_services.get_user_contributions(key, strict=False) is not None:\n+            user_services.update_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n+        else:\n+            user_services.create_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n',
   }
 
+  const jobTestFile = {
+    sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
+    filename: 'core/domain/exp_jobs_oppiabot_off_test.py',
+    status: 'added',
+    additions: 1,
+    deletions: 0,
+    changes: 1,
+    blob_url:
+      'https://github.com/oppia/oppia/blob/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    raw_url:
+      'https://github.com/oppia/oppia/raw/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    contents_url:
+      'https://api.github.com/repos/oppia/oppia/contents/core/domain/exp_jobs_oppiabot_off.py?ref=67fb4a973b318882af3b5a894130e110d7e9833c',
+    patch: '@@ -0,0 +1 @@\n+class TestOneOffJobTests(jobs.BaseMapReduceOneOffJobManager):\n+    """One-off job for creating and populating UserContributionsModels for \n+class AnotherTestOneOffJobTests(jobs.BaseMapReduceOneOffJobManager):\n+    """\n+    @classmethod\n+    def entity_classes_to_map_over(cls):\n+        """Return a list of datastore class references to map over."""\n+        return [exp_models.ExplorationSnapshotMetadataModel]\n+\n+    @staticmethod\n+    def map(item):\n+        """Implements the map function for this job."""\n+        yield (\n+            item.committer_id, {\n+                \'exploration_id\': item.get_unversioned_instance_id(),\n+                \'version_string\': item.get_version_string(),\n+            })\n+\n+\n+    @staticmethod\n+    def reduce(key, version_and_exp_ids):\n+        """Implements the reduce function for this job."""\n+        created_exploration_ids = set()\n+        edited_exploration_ids = set()\n+\n+        edits = [ast.literal_eval(v) for v in version_and_exp_ids]\n+\n+        for edit in edits:\n+            edited_exploration_ids.add(edit[\'exploration_id\'])\n+            if edit[\'version_string\'] == \'1\':\n+                created_exploration_ids.add(edit[\'exploration_id\'])\n+\n+        if user_services.get_user_contributions(key, strict=False) is not None:\n+            user_services.update_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n+        else:\n+            user_services.create_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n',
+  }
+
   const registryFileObjWithNewjob = {
     sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
     filename: 'core/jobs_registry.py',
@@ -596,6 +612,9 @@ describe('Pull Request Job Spec', () => {
       expect(jobs.length).toBe(2);
       expect(jobs[0]).toBe('TestOneOffJob');
       expect(jobs[1]).toBe('AnotherTestOneOffJob');
+
+      jobs = checkPullRequestJobModule.getNewJobsFromFile(jobTestFile);
+      expect(jobs.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Prevent oppiabot from checking job tests and refactor job check such that all files are checked for job. The job regex is updated to have an opening bracket after job name so that no job test classes are captured by the regex. We check for all files since finding the job should be handled by the regex directly irrespective of the file. Further, this won't be an overhead since the max number of files will be 3000. The benefit to using this is that it simplifies the code logic.

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
