### PR TITLE
Fix issue with Job check

### DIFF
--- a/lib/checkPullRequestJob.js
+++ b/lib/checkPullRequestJob.js
@@ -17,9 +17,9 @@ const getNewJobsFromFile = (file) => {
   // This represents an new line added from the git diff.
   // This is done because classes can only be created in a new line.
   // '+' represents an addition while '-' represents a deletion.
-  const newLineAdded = '\n+';
-  const changesArray = file.patch.split(newLineAdded);
-  const jobRegex = /(?<classDefinition>class\s)(?<jobName>[a-zA-Z]{2,256})(?<jobSuffix>OneOffJob)(?<funDef>\()/;
+  const newLine = '\n';
+  const changesArray = file.patch.split(newLine);
+  const jobRegex = /(?<addition>\+)(?<classDefinition>class\s)(?<jobName>[a-zA-Z]{2,256})(?<jobSuffix>OneOffJob)(?<funDef>\()/;
 
   const newJobDefinitions = changesArray.filter(change => {
     const matches = jobRegex.exec(change);

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -94,6 +94,22 @@ describe('Pull Request Job Spec', () => {
     patch: '@@ -0,0 +1 @@class SecondTestOneOffJob(jobs.BaseMapReduceOneOffJobManager)  def reduce(key, version_and_exp_ids):\n                     edited_exploration_ids))\n ',
   };
 
+  const jobFileObjWithJobClassInPatchAndNewJob = {
+    sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
+    filename: 'core/domain/exp_jobs_oppiabot_off.py',
+    status: 'modified',
+    additions: 1,
+    deletions: 0,
+    changes: 1,
+    blob_url:
+      'https://github.com/oppia/oppia/blob/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    raw_url:
+      'https://github.com/oppia/oppia/raw/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    contents_url:
+      'https://api.github.com/repos/oppia/oppia/contents/core/domain/exp_jobs_oppiabot_off.py?ref=67fb4a973b318882af3b5a894130e110d7e9833c',
+    patch: '@@ -0,0 +1 @@class SecondTestOneOffJob(jobs.BaseMapReduceOneOffJobManager)  def reduce(key, version_and_exp_ids):\n                     edited_exploration_ids))\n \n+class AnotherTestOneOffJob(jobs.BaseMapReduceOneOffJobManager):\n+    """\n+    @classmethod\n+    def entity_classes_to_map_over ',
+  };
+
   const jobFromTestDir = {
     sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
     filename: 'core/tests/linter_tests/exp_jobs_oppiabot_off.py',
@@ -664,6 +680,11 @@ describe('Pull Request Job Spec', () => {
       jobs = checkPullRequestJobModule.getNewJobsFromFile(
         modifiedExistingJobFileObjWithJobClassInPatch)
       expect(jobs.length).toBe(0);
+
+      jobs = checkPullRequestJobModule.getNewJobsFromFile(
+        jobFileObjWithJobClassInPatchAndNewJob)
+      expect(jobs.length).toBe(1);
+      expect(jobs[0]).toBe('AnotherTestOneOffJob');
     });
   });
 });

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -78,6 +78,21 @@ describe('Pull Request Job Spec', () => {
     patch:
       '@@ -80,6 +80,49 @@ def reduce(key, version_and_exp_ids):\n                     edited_exploration_ids))\n \n \n+class OppiabotContributionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):\n+    """One-off job for creating and populating UserContributionsModels for\n+    all registered users that have contributed.\n+    """\n+    @classmethod\n+    def entity_classes_to_map_over(cls):\n+        """Return a list of datastore class references to map over."""\n+        return [exp_models.ExplorationSnapshotMetadataModel]\n+\n+    @staticmethod\n+    def map(item):\n+        """Implements the map function for this job."""\n+        yield (\n+            item.committer_id, {\n+                \'exploration_id\': item.get_unversioned_instance_id(),\n+                \'version_string\': item.get_version_string(),\n+            })\n+\n+\n+    @staticmethod\n+    def reduce(key, version_and_exp_ids):\n+        """Implements the reduce function for this job."""\n+        created_exploration_ids = set()\n+        edited_exploration_ids = set()\n+\n+        edits = [ast.literal_eval(v) for v in version_and_exp_ids]\n+\n+        for edit in edits:\n+            edited_exploration_ids.add(edit[\'exploration_id\'])\n+            if edit[\'version_string\'] == \'1\':\n+                created_exploration_ids.add(edit[\'exploration_id\'])\n+\n+        if user_services.get_user_contributions(key, strict=False) is not None:\n+            user_services.update_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n+        else:\n+            user_services.create_user_contributions(\n+                key, list(created_exploration_ids), list(\n+                    edited_exploration_ids))\n',
   };
+  const modifiedExistingJobFileObjWithJobClassInPatch = {
+    sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
+    filename: 'core/domain/exp_jobs_oppiabot_off.py',
+    status: 'modified',
+    additions: 1,
+    deletions: 0,
+    changes: 1,
+    blob_url:
+      'https://github.com/oppia/oppia/blob/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    raw_url:
+      'https://github.com/oppia/oppia/raw/67fb4a973b318882af3b5a894130e110d7e9833c/core/domain/exp_jobs_oppiabot_off.py',
+    contents_url:
+      'https://api.github.com/repos/oppia/oppia/contents/core/domain/exp_jobs_oppiabot_off.py?ref=67fb4a973b318882af3b5a894130e110d7e9833c',
+    patch: '@@ -0,0 +1 @@class SecondTestOneOffJob(jobs.BaseMapReduceOneOffJobManager)  def reduce(key, version_and_exp_ids):\n                     edited_exploration_ids))\n ',
+  };
 
   const jobFromTestDir = {
     sha: 'd144f32b9812373d5f1bc9f94d9af795f09023ff',
@@ -644,6 +659,10 @@ describe('Pull Request Job Spec', () => {
       expect(jobs[1]).toBe('AnotherTestOneOffJob');
 
       jobs = checkPullRequestJobModule.getNewJobsFromFile(jobTestFile);
+      expect(jobs.length).toBe(0);
+
+      jobs = checkPullRequestJobModule.getNewJobsFromFile(
+        modifiedExistingJobFileObjWithJobClassInPatch)
       expect(jobs.length).toBe(0);
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Sometimes, the file patch contains job class declarations even when new jobs weren't defined. 
This PR makes oppiabot only respond to job class additions and hence ignore other job classes that were not added but became a part of the patch.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
