### PR TITLE
Fix #112: Add check for translate wiki

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -76,6 +76,8 @@ const checksWhitelist = {
   }
 };
 
+const blacklistedAuthors = ['translatewiki'];
+
 module.exports.openEvent = openEvent;
 module.exports.reopenEvent = reopenEvent;
 module.exports.unlabelEvent = unlabelEvent;
@@ -102,6 +104,10 @@ module.exports.datastoreLabelCheck = datastoreLabelCheck;
 module.exports.prLabelCheck = prLabelCheck;
 module.exports.prTemplateCheck = prTemplateCheck;
 module.exports.forcePushCheck = forcePushCheck;
+
+module.exports.getBlacklistedAuthors = function() {
+  return blacklistedAuthors;
+};
 
 module.exports.getChecksWhitelist = function() {
   return checksWhitelist;

--- a/spec/apiForSheetsSpec.js
+++ b/spec/apiForSheetsSpec.js
@@ -375,4 +375,25 @@ describe('Api For Sheets Module', () => {
       expect(checkPullRequestJobModule.checkForNewJob).not.toHaveBeenCalled();
     });
   });
+
+  describe('should not run checks for a blacklisted author', () => {
+    beforeEach(function (done) {
+      spyOn(apiForSheetsModule, 'checkClaStatus').and.callThrough();
+      spyOn(apiForSheetsModule, 'authorize').and.callThrough({});
+      spyOn(apiForSheetsModule, 'checkClaSheet').and.callThrough();
+      spyOn(constants, 'getBlacklistedAuthors').and.returnValue([
+        'testuser7777']);
+      robot.receive(pullRequestPayload);
+      done();
+    });
+
+    it('should not call any checks', () => {
+      expect(
+        checkPullRequestLabelsModule.checkChangelogLabel).not.toHaveBeenCalled();
+      expect(checkPullRequestBranchModule.checkBranch).not.toHaveBeenCalled();
+      expect(checkWipModule.checkWIP).not.toHaveBeenCalled();
+      expect(apiForSheetsModule.checkClaStatus).not.toHaveBeenCalled();
+      expect(checkPullRequestJobModule.checkForNewJob).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Explanation
Fixes #112: Adds a check to ensure oppiabot does not run on translate wiki PRs

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
