### PR TITLE
Fix assignee check related issues

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -49,6 +49,7 @@ const checksWhitelist = {
     [openEvent]: [
       claCheck,
       changelogCheck,
+      codeOwnerCheck,
       branchCheck,
       wipCheck,
       jobCheck,

--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -155,6 +155,13 @@ module.exports.checkAssignee = async function(context) {
     'RUNNING ASSIGNEE CHECK ON PULL REQUEST ' + pullRequestNumber + ' ...'
   );
 
+  const assignees = pullRequest.assignees.map(assignee => assignee.login);
+  if (assignees.length !== 0) {
+    // We do not update the assignees if the pull request already has a
+    // main reviewer/author assigned.
+    return;
+  }
+
   var changelogLabel = context.payload.label.name.trim();
   var hasChangelogLabel = isChangelogLabel(changelogLabel)
 
@@ -173,27 +180,21 @@ module.exports.checkAssignee = async function(context) {
     const shouldAssignProjectOwner = canAssignProjectOwner(
       pullRequest, changelogLabel);
     if (shouldAssignProjectOwner) {
-      const assignees = pullRequest.assignees.map(assignee => assignee.login);
-      if(!assignees.includes(projectOwner)) {
-        var assigneeParams = context.issue({ assignees: [projectOwner] });
-        await context.github.issues.addAssignees(assigneeParams);
+      var assigneeParams = context.issue({ assignees: [projectOwner] });
+      await context.github.issues.addAssignees(assigneeParams);
 
-        var commentParams = context.issue({
-          body:
-            'Assigning @' +
-            projectOwner +
-            ' for the first-pass review of this pull request. Thanks!',
-        });
-        await context.github.issues.createComment(commentParams);
-      }
+      var commentParams = context.issue({
+        body:
+          'Assigning @' +
+          projectOwner +
+          ' for the first-pass review of this pull request. Thanks!',
+      });
+      await context.github.issues.createComment(commentParams);
       // Project owner is already assigned so we do nothing.
     } else {
       // Attempt to assign all codeowners.
       await assignAllCodeowners(context);
     }
-
-    // Check for new codeowner.
-    await newCodeownerModule.checkForNewCodeowner(context);
   }
   // If no changelog label is found, no action is required.
 };
@@ -262,7 +263,7 @@ module.exports.checkChangelogLabel = async function(context) {
   }
 
   // If no changelog label is found, ping the author in the PR
-  // thread and ask him/her to add a label.
+  // thread and ask them to add a label.
   var stateCommentParams = context.issue({
     body:
       'Hi, @' +

--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -19,7 +19,6 @@ const utilityModule = require('./utils');
 const CHANGES_REQUESTED = 'changes_requested';
 const COMMENTED = 'commented';
 const LGTM_LABEL = 'PR: LGTM';
-const THREE_MINUTES = 60 * 1000 * 3;
 const CLOSED_STATE = 'closed';
 const PTAL_COMMENTS = ['PTAL', 'Please take a look'];
 
@@ -266,7 +265,7 @@ const handlePullRequestReview = async (context) => {
   }
   // Pause for 3 minutes in case reviewer wants to perform
   // the required actions.
-  await utilityModule.sleep(THREE_MINUTES);
+  await utilityModule.sleep(utilityModule.THREE_MINUTES);
   // Fetch the pull request incase there has been any changes since
   // the review was made.
   const pullRequestResponse = await context.github.pulls.get(
@@ -327,7 +326,7 @@ const handleResponseToReview = async (context) => {
 
   // Pause for 3 minutes in case author wants to perform
   // the required actions.
-  await utilityModule.sleep(THREE_MINUTES);
+  await utilityModule.sleep(utilityModule.THREE_MINUTES);
 
   // Fetch the pull request in case there has been any changes since
   // the comment was made.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,7 @@ const LABELS_EXCLUDED_FROM_CODEOWNER_ASSIGNMENT = [
 const CODE_OWNERS_FILE_URL =
   'https://raw.githubusercontent.com/oppia/oppia/develop/.github/CODEOWNERS';
 const CHANGELOG_START = 'PR CHANGELOG';
+const THREE_MINUTES = 60 * 1000 * 3;
 
 /**
  * Gets all the changed files in the repo

--- a/spec/apiForSheetsSpec.js
+++ b/spec/apiForSheetsSpec.js
@@ -15,6 +15,7 @@ const commitsData = JSON.parse(
 const checkPullRequestJobModule = require('../lib/checkPullRequestJob');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
 const checkPullRequestTemplateModule = require('../lib/checkPullRequestTemplate');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 const {google} = require('googleapis');
 const {OAuth2Client} = require('google-auth-library');
 
@@ -43,6 +44,7 @@ describe('Api For Sheets Module', () => {
     spyOn(checkWipModule, 'checkWIP').and.callFake(() => {});
     spyOn(checkCriticalPullRequestModule, 'checkIfPRAffectsDatastoreLayer').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule,'checkTemplate').and.callFake(() => {});
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
 
     github = {
       issues: {

--- a/spec/checkCriticalPullRequestSpec.js
+++ b/spec/checkCriticalPullRequestSpec.js
@@ -27,6 +27,7 @@ const checkPullRequestBranchModule = require('../lib/checkPullRequestBranch');
 const checkWIPModule = require('../lib/checkWipDraftPR');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
 const checkPullRequestTemplateModule = require('../lib/checkPullRequestTemplate');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 const scheduler = require('../lib/scheduler');
 const {
   teamLeads,
@@ -200,6 +201,7 @@ describe('Critical Pull Request Spec', () => {
     spyOn(checkPullRequestBranchModule, 'checkBranch').and.callFake(() => {});
     spyOn(checkWIPModule, 'checkWIP').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule,'checkTemplate').and.callFake(() => {});
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
 
     spyOn(checkCriticalPullRequestModule, 'checkIfPRAffectsDatastoreLayer').and.callThrough();
   });

--- a/spec/checkPullRequestBranchSpec.js
+++ b/spec/checkPullRequestBranchSpec.js
@@ -25,6 +25,7 @@ const checkPullRequestBranchModule = require('../lib/checkPullRequestBranch');
 const checkPullRequestJobModule = require('../lib/checkPullRequestJob');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
 const checkPullRequestTemplateModule = require('../lib/checkPullRequestTemplate');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 
 describe('Pull Request Branch Check', () => {
   /**
@@ -55,6 +56,7 @@ describe('Pull Request Branch Check', () => {
     spyOn(checkPullRequestJobModule, 'checkForNewJob').and.callFake(() => {});
     spyOn(checkCriticalPullRequestModule, 'checkIfPRAffectsDatastoreLayer').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule,'checkTemplate').and.callFake(() => {});
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
 
     github = {
       issues: {

--- a/spec/checkPullRequestJobSpec.js
+++ b/spec/checkPullRequestJobSpec.js
@@ -9,6 +9,7 @@ const checkPullRequestBranchModule = require('../lib/checkPullRequestBranch');
 const checkWIPModule = require('../lib/checkWipDraftPR');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
 const checkPullRequestTemplateModule = require('../lib/checkPullRequestTemplate');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 const scheduler = require('../lib/scheduler');
 
 let payloadData = JSON.parse(
@@ -221,6 +222,7 @@ describe('Pull Request Job Spec', () => {
     spyOn(checkPullRequestBranchModule, 'checkBranch').and.callFake(() => {});
     spyOn(checkWIPModule, 'checkWIP').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule,'checkTemplate').and.callFake(() => {});
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
   });
 
   describe('When a new job file is created in a pull request', () => {

--- a/spec/checkPullRequestReviewSpec.js
+++ b/spec/checkPullRequestReviewSpec.js
@@ -41,7 +41,6 @@ describe('Pull Request Review Module', () => {
    */
   let app;
 
-  const THREE_MINUTES = 180000;
   beforeEach(() => {
     spyOn(scheduler, 'createScheduler').and.callFake(() => {});
 
@@ -91,7 +90,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should unassign reviewer', async () => {
@@ -160,7 +160,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should unassign reviewer', async () => {
@@ -224,7 +225,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should not unassign reviewer', async () => {
@@ -280,7 +282,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should not unassign reviewer', async () => {
@@ -316,7 +319,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should not unassign reviewer', async () => {
@@ -381,7 +385,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should unassign reviewer', async () => {
@@ -484,7 +489,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should unassign reviewer', async () => {
@@ -583,7 +589,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should unassign reviewer', async () => {
@@ -692,7 +699,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should not unassign reviewer', async () => {
@@ -797,7 +805,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should unassign reviewer', async () => {
@@ -912,7 +921,8 @@ describe('Pull Request Review Module', () => {
 
       it('should wait for 3 minutes before performing any action', () => {
         expect(utilityModule.sleep).toHaveBeenCalled();
-        expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should unassign reviewer', async () => {
@@ -986,7 +996,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should not unassign reviewer', async () => {
@@ -1084,7 +1095,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should get the updated version of the pull request', () => {
@@ -1156,7 +1168,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should get the updated version of the pull request', () => {
@@ -1209,7 +1222,8 @@ describe('Pull Request Review Module', () => {
 
         it('should wait for 3 minutes before performing any action', () => {
           expect(utilityModule.sleep).toHaveBeenCalled();
-          expect(utilityModule.sleep).toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should get the updated version of the pull request', () => {
@@ -1258,7 +1272,8 @@ describe('Pull Request Review Module', () => {
 
       it('should not wait for 3 minutes', () => {
         expect(utilityModule.sleep).not.toHaveBeenCalled();
-        expect(utilityModule.sleep).not.toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).not.toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should not get the updated version of the pull request', () => {
@@ -1314,7 +1329,8 @@ describe('Pull Request Review Module', () => {
 
       it('should not wait for 3 minutes', () => {
         expect(utilityModule.sleep).not.toHaveBeenCalled();
-        expect(utilityModule.sleep).not.toHaveBeenCalledWith(THREE_MINUTES);
+        expect(utilityModule.sleep).not.toHaveBeenCalledWith(
+          utilityModule.THREE_MINUTES);
       });
 
       it('should not get the updated version of the pull request', () => {
@@ -1362,7 +1378,8 @@ describe('Pull Request Review Module', () => {
 
         it('should not wait for 3 minutes', () => {
           expect(utilityModule.sleep).not.toHaveBeenCalled();
-          expect(utilityModule.sleep).not.toHaveBeenCalledWith(THREE_MINUTES);
+          expect(utilityModule.sleep).not.toHaveBeenCalledWith(
+            utilityModule.THREE_MINUTES);
         });
 
         it('should not get the updated version of the pull request', () => {

--- a/spec/checkPullRequestTemplateSpec.js
+++ b/spec/checkPullRequestTemplateSpec.js
@@ -25,6 +25,7 @@ const checkPullRequestLabelsModule = require('../lib/checkPullRequestLabels');
 const checkPullRequestBranchModule = require('../lib/checkPullRequestBranch');
 const checkWIPModule = require('../lib/checkWipDraftPR');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 const scheduler = require('../lib/scheduler');
 const payloadData = JSON.parse(
   JSON.stringify(require('../fixtures/pullRequestPayload.json'))
@@ -214,6 +215,7 @@ describe('Pull Request Template', () => {
     spyOn(checkPullRequestBranchModule, 'checkBranch').and.callFake(() => {});
     spyOn(checkWIPModule, 'checkWIP').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule, 'checkTemplate').and.callThrough();
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
   });
 
   describe('when pull request with invalid template is created', () => {

--- a/spec/checkWipDraftPRSpec.js
+++ b/spec/checkWipDraftPRSpec.js
@@ -24,6 +24,7 @@ const checkPullRequestLabelsModule = require('../lib/checkPullRequestLabels');
 const checkPullRequestJobModule = require('../lib/checkPullRequestJob');
 const checkCriticalPullRequestModule = require('../lib/checkCriticalPullRequest');
 const checkPullRequestTemplateModule = require('../lib/checkPullRequestTemplate');
+const newCodeOwnerModule = require('../lib/checkForNewCodeowner');
 
 describe('Oppiabot\'s', () => {
   /**
@@ -52,6 +53,7 @@ describe('Oppiabot\'s', () => {
     spyOn(checkPullRequestJobModule, 'checkForNewJob').and.callFake(() => {});
     spyOn(checkCriticalPullRequestModule, 'checkIfPRAffectsDatastoreLayer').and.callFake(() => {});
     spyOn(checkPullRequestTemplateModule,'checkTemplate').and.callFake(() => {});
+    spyOn(newCodeOwnerModule, 'checkForNewCodeowner').and.callFake(() => {});
 
     github = {
       issues: {


### PR DESCRIPTION
## Explanation
Fixes the following issues:

1. We currently assign the project owner/codeowners whenever a changelog label is added to the pull request. This feature should only work if no one is already assigned to the pull request. So, the lib is updated such that new assignees will only be added if there are no current assignees.
2. We run the codeowners check whenever a label is added and it is a changelog label. This is buggy again because there can be a case when changelog label is changed and we don't need to re-run the codeowner check. So, the codeowner check is now run only when PR is opened or synchronized.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).  -- Trivial change, does not require extra testing.
