### PR TITLE
Fix #125: Codeowner bug

### DIFF
--- a/lib/checkForNewCodeowner.js
+++ b/lib/checkForNewCodeowner.js
@@ -21,6 +21,7 @@ const { isChangelogLabel } = require('./utils');
 const CODE_OWNER_FILE_NAME = '.github/CODEOWNERS';
 const newLine = '\n';
 const newAddition = '+';
+const newCommentAddition = '+#'
 const usernameDefiner = '@';
 
 /**
@@ -31,7 +32,7 @@ const usernameDefiner = '@';
 const getNewCodeOwners = (file) => {
   const changesArray = file.patch.split(newLine);
   const newAdditions = changesArray.filter((change) => {
-    return change.startsWith(newAddition);
+    return change.startsWith(newAddition) && !change.startsWith(newCommentAddition);
   });
 
   /**
@@ -169,4 +170,5 @@ const checkForNewCodeowner = async (context) => {
 
 module.exports = {
   checkForNewCodeowner,
+  getNewCodeOwners
 };

--- a/spec/checkForNewCodeownerSpec.js
+++ b/spec/checkForNewCodeownerSpec.js
@@ -432,7 +432,7 @@ describe('check for new code owner', () => {
   it('Should get new codeowner from files', () => {
     spyOn(newCodeOwnerModule, 'getNewCodeOwners').and.callThrough();
 
-    // Payload from https://github.com/oppia/oppia/pull/10534
+    // Payload from https://github.com/oppia/oppia/pull/10534.
     const fileWithComments = {
       sha: '6911619e95dfcb11eb2204fba88987e5abf02352',
       filename: '.github/CODEOWNERS',

--- a/spec/checkForNewCodeownerSpec.js
+++ b/spec/checkForNewCodeownerSpec.js
@@ -428,4 +428,54 @@ describe('check for new code owner', () => {
       payloadData.payload.pull_request.labels.pop();
     });
   });
+
+  it('Should get new codeowner from files', () => {
+    spyOn(newCodeOwnerModule, 'getNewCodeOwners').and.callThrough();
+
+    // Payload from https://github.com/oppia/oppia/pull/10534
+    const fileWithComments = {
+      sha: '6911619e95dfcb11eb2204fba88987e5abf02352',
+      filename: '.github/CODEOWNERS',
+      status: 'modified',
+      additions: 82,
+      deletions: 58,
+      changes: 140,
+      blob_url:
+        'https://github.com/oppia/oppia/blob/c876111ec9c743179483d7ca75e348b' +
+        '8680b13ec/.github/CODEOWNERS',
+      raw_url:
+        'https://github.com/oppia/oppia/raw/c876111ec9c743179483d7ca75e348b8' +
+        '680b13ec/.github/CODEOWNERS',
+      contents_url:
+        'https://api.github.com/repos/oppia/oppia/contents/.github/CODEOWNERS' +
+      '?ref=c876111ec9c743179483d7ca75e348b8680b13ec',
+      patch:
+        '-/extensions/ @vojtechjelinek\r\n+# TODO(#10538): Revert ownership ' +
+        'to @vojtechjelinek after 2020-09-06.\r\n+/extensions/ @seanlip\r\n/'+
+        'core/templates/services/UpgradedServices.ts @bansalnitish '+
+        '@srijanreddy98\r\n/typings/ @ankita240796\r\n/tsconfig.json '+
+        '@ankita240796\r\n-/tsconfig-strict.json @nishantwrp @vojtechjelinek' +
+        '\r\n+# TODO(#10538): Add @vojtechjelinek as an owner after 2020-09-' +
+        '06.\r\n+/tsconfig-strict.json @nishantwrp\r\n-/core/controllers/' +
+        'resources*.py @vojtechjelinek\r\n+# TODO(#10538): Revert ownership ' +
+        'to @vojtechjelinek after 2020-09-06.\r\n-/core/controllers/' +
+        'resources*.py @seanlip'
+    }
+
+    let codeowners = newCodeOwnerModule.getNewCodeOwners(fileWithComments);
+    expect(codeowners.length).toBe(2);
+    expect(codeowners).toEqual(['@seanlip', '@nishantwrp']);
+
+    codeowners = newCodeOwnerModule.getNewCodeOwners(nonCodeOwnerFile)
+    expect(codeowners.length).toBe(0)
+
+    codeowners = newCodeOwnerModule.getNewCodeOwners(codeOwnerFileWithNewUser)
+    expect(codeowners.length).toBe(2)
+    expect(codeowners).toEqual(['@testuser', '@vojtechjelinek']);
+
+    codeowners = newCodeOwnerModule.getNewCodeOwners(codeOwnerFileWithMultipleNewUsers)
+    expect(codeowners.length).toBe(4)
+    expect(codeowners).toEqual(['@testuser', '@vojtechjelinek', '@testuser2', '@jameesjohn']);
+  });
 });
+


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #125: The code owner check was not ignoring comments, and since the PR added a comment that included usernames, oppiabot took it as a new code owner.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
