### PR TITLE
Fix #187 : Update Oppiabot comment for asking team-leads to merge other's PRs. 

### DIFF
--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -128,9 +128,9 @@ const handleApprovalByAllReviewers = async (context, pullRequest) => {
       'Hi @' +
       projectOwner +
       ', this PR is ready to be merged. Author of this PR ' +
-      'do not have permissions to merge this PR. Before you merge it, ' +
+      'does not have permissions to merge this PR. Before you merge it, ' +
       'please make sure that there are no pending comments that require ' +
-      "action from the author's end. Thanks!";
+      'action from the author\'s end. Thanks!';
     await utilityModule.pingAndAssignUsers(
       context,
       pullRequest,

--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -127,8 +127,9 @@ const handleApprovalByAllReviewers = async (context, pullRequest) => {
     const commentBody =
       'Hi @' +
       projectOwner +
-      ', this PR is ready to be merged. Before you merge it, please ' +
-      'make sure that there are no pending comments that require ' +
+      ', this PR is ready to be merged. Author of this PR ' +
+      'do not have permissions to merge this PR. Before you merge it, ' +
+      'please make sure that there are no pending comments that require ' +
       "action from the author's end. Thanks!";
     await utilityModule.pingAndAssignUsers(
       context,

--- a/spec/checkPullRequestReviewSpec.js
+++ b/spec/checkPullRequestReviewSpec.js
@@ -764,10 +764,10 @@ describe('Pull Request Review Module', () => {
             issue_number: reviewPayloadData.payload.pull_request.number,
             body:
               'Hi @kevintab95, this PR is ready to be merged. ' +
-              'Author of this PR do not have permissions ' +
+              'Author of this PR does not have permissions ' +
               'to merge this PR. Before you ' +
               'merge it, please make sure that there are no pending comments ' +
-              "that require action from the author's end. Thanks!",
+              'that require action from the author\'s end. Thanks!',
           });
         });
 

--- a/spec/checkPullRequestReviewSpec.js
+++ b/spec/checkPullRequestReviewSpec.js
@@ -763,7 +763,9 @@ describe('Pull Request Review Module', () => {
             repo: reviewPayloadData.payload.repository.name,
             issue_number: reviewPayloadData.payload.pull_request.number,
             body:
-              'Hi @kevintab95, this PR is ready to be merged. Before you ' +
+              'Hi @kevintab95, this PR is ready to be merged. ' +
+              'Author of this PR do not have permissions ' +
+              'to merge this PR. Before you ' +
               'merge it, please make sure that there are no pending comments ' +
               "that require action from the author's end. Thanks!",
           });

--- a/spec/periodicChecksSpec.js
+++ b/spec/periodicChecksSpec.js
@@ -538,7 +538,9 @@ describe('Periodic Checks Module', () => {
           owner: 'oppia',
           repo: 'oppia',
           body:
-            'Hi @ankita240796, this PR is ready to be merged. Before you ' +
+            'Hi @ankita240796, this PR is ready to be merged. ' +
+            'Author of this PR do not have permissions ' +
+            'to merge this PR. Before you ' +
             'merge it, please make sure that there are no pending comments ' +
             "that require action from the author's end. Thanks!",
         });

--- a/spec/periodicChecksSpec.js
+++ b/spec/periodicChecksSpec.js
@@ -539,10 +539,10 @@ describe('Periodic Checks Module', () => {
           repo: 'oppia',
           body:
             'Hi @ankita240796, this PR is ready to be merged. ' +
-            'Author of this PR do not have permissions ' +
+            'Author of this PR does not have permissions ' +
             'to merge this PR. Before you ' +
             'merge it, please make sure that there are no pending comments ' +
-            "that require action from the author's end. Thanks!",
+            'that require action from the author\'s end. Thanks!',
         });
       });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

PR fixes #187 
Modifies the message for team leads to merge the PR for the author with no write permissions to oppia. 

From : 
```
Hi @<team-lead>, this PR is ready to be merged. Before you merge it, please make sure that there are no pending comments that require action from the author's end. Thanks!
```

To: 
```
Hi @<team-lead>, this PR is ready to be merged. Author of this PR do not have permissions to merge this PR. Before you merge it, please make sure that there are no pending comments that require action from the author's end. Thanks!
```


## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
