### PR TITLE
Fix #157: Ensure that every issue is assigned to a project

### DIFF
--- a/lib/checkIssueProject.js
+++ b/lib/checkIssueProject.js
@@ -1,0 +1,22 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @param {import('probot').Context} context
+ */
+const checkAssignedProject = async(context) => {
+    // TODO - check if issue has a project assigned or not
+    const issueComment = context.issue({ body: 'Issue should be added to a project' })
+    await context.github.issues.createComment(issueComment)
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #157 
Added a file which will comment on issue `Issue should be added to a project`

@jameesjohn 
I am taking this PR in 4 steps:
1. created a new check file `checkIssueProject.js` which is check if issue has a project assigned or not and if not, it will comment on issue `Issue should be added to a project`. 
    As of now, I had created this file and make it create a comment.
2. Need to add condition if an issue is assigned to a project or not.  `{import('probot').Octokit.....}` Finding something here which helps me to get assigned project, but didn't find anything. 
3. Add `*spec.js` file.=
4. Manual Testing

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
