### PR TITLE
Fix #178: added check for proof of changes

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -110,6 +110,26 @@ const checksWhitelist = {
     [issuesAssignedEvent]: [],
     [pushEvent]: []
   },
+  'oppiabot-test-repo': {
+    [openEvent]: [
+      claCheck,
+      changelogCheck,
+      codeOwnerCheck,
+      branchCheck,
+      wipCheck,
+      jobCheck,
+      modelCheck,
+      prTemplateCheck
+    ],
+    [reopenEvent]: [
+      changelogCheck,
+      branchCheck,
+      wipCheck,
+      jobCheck,
+      modelCheck,
+      prTemplateCheck
+    ],
+  }
 };
 
 const blacklistedAuthors = ['translatewiki'];

--- a/constants.js
+++ b/constants.js
@@ -110,26 +110,6 @@ const checksWhitelist = {
     [issuesAssignedEvent]: [],
     [pushEvent]: []
   },
-  'oppiabot-test-repo': {
-    [openEvent]: [
-      claCheck,
-      changelogCheck,
-      codeOwnerCheck,
-      branchCheck,
-      wipCheck,
-      jobCheck,
-      modelCheck,
-      prTemplateCheck
-    ],
-    [reopenEvent]: [
-      changelogCheck,
-      branchCheck,
-      wipCheck,
-      jobCheck,
-      modelCheck,
-      prTemplateCheck
-    ],
-  }
 };
 
 const blacklistedAuthors = ['translatewiki'];

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -195,7 +195,7 @@ const checkEssentialChecklist = (pullRequest) => {
  *
  * @param {import('probot').Octokit.PullsGetResponse} pullRequest
  */
-const checkProofThatChangesAreCorrect = (pullRequest) => {
+const checkProofOfChanges = (pullRequest) => {
   /*
     A valid 'Proof that changes are correct' section would either:
       1. Contain a link to some image or video that contains the proof.
@@ -237,9 +237,7 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
   const proofIsNotPossible = proofOfChangesSection.replace(
     PROOF_HTML_COMMENT, ''
   ).match(PROOF_UNAVAILABLE_TEXT);
-  console.log(proofOfChangesSection.replace(
-    PROOF_HTML_COMMENT, ''
-  ).match(PROOF_UNAVAILABLE_TEXT));
+
   const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
   // Check if there are images/videos added in the section.
@@ -264,10 +262,9 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
 const generateComment = (pullRequest) => {
   const explanationMessage = checkPRExplanation(pullRequest);
   const checklistMessage = checkEssentialChecklist(pullRequest);
-  const proofOfChangesMessage = checkProofThatChangesAreCorrect(pullRequest);
+  const proofOfChangesMessage = checkProofOfChanges(pullRequest);
 
   let count = 1;
-
   let commentBody = (
     'Hi @' + pullRequest.user.login + ', can you complete the following:\n');
 
@@ -292,7 +289,6 @@ const generateComment = (pullRequest) => {
   }
 
   commentBody += 'Thanks!';
-
   return commentBody.trim();
 };
 

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -22,7 +22,10 @@ const KARMA_LINTER = 'linter/karma';
 const EXPLANATION_TEXT = '[Explain here what your PR does and why]';
 const CHECKLIST_TEXT = '## Essential Checklist';
 const PROOF_TEXT = '## Proof that changes are correct';
-const UPLOADED_MEDIA = 'user-images.githubusercontent.com';
+const UPLOADED_MEDIA = 'http';
+const PROOF_UNAVAILABLE_TEXT = 'No proof of changes needed because';
+// Add the "\r\n" in the regex for every new line.
+const PROOF_HTML_COMMENT = /<!--\r\n.*\r\n.*\r\n-->/;
 const EDITS_FROM_MAINTAINERS_TEXT = 'allow edits from maintainers';
 const UNCHECKED_CHECKLIST = '- [ ]';
 const EXPLANATION_START = '2';
@@ -186,8 +189,8 @@ const checkEssentialChecklist = (pullRequest) => {
 
 /**
  * This function checks if the pull request's body contains the
- * checklist and returns an appropriate message if the required
- * checklist items are not checked.
+ * proof of changes and returns an appropriate message if the required
+ * proofs are not provided.
  *
  * @param {import('probot').Octokit.PullsGetResponse} pullRequest
  */
@@ -219,10 +222,13 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
       nextHeadingIndex
     );
 
-    var proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
+    const proofUnavailable = proofOfChangesSection
+      .replace(PROOF_HTML_COMMENT, '').includes(PROOF_UNAVAILABLE_TEXT);
+
+    const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
     // Check if there are images/videos added in the section.
-    if (!proofLinks){
+    if (!proofLinks && !proofUnavailable){
       return (
         'The proof that changes are correct has not been provided, ' +
         'please make sure to upload a image/video showing that the changes ' +
@@ -237,45 +243,39 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
   }
 };
 
-
 /**
  * This function checks that a PR follows the appropriate template and
  * comments on the PR if key parts of the template is missing.
  *
  * @param {import('probot').Context} context
  */
-const checkTemplate = async (context) => {
-  /**
-   * @type {import('probot').Octokit.PullsGetResponse} pullRequest
-   */
-  const pullRequest = context.payload.pull_request;
-
+const generateComment = (pullRequest) => {
   const explanationMessage = checkPRExplanation(pullRequest);
   const checklistMessage = checkEssentialChecklist(pullRequest);
   const proofOfChangesMessage = checkProofThatChangesAreCorrect(pullRequest);
   let commentBody = '';
 
-  count = 1;
+  var count = 1;
 
-  commentBodybasic = commentBody =
+  var commentBodybasic = commentBody =
       'Hi @' +
       pullRequest.user.login +
       ', can you complete the following:\n';
 
   if (explanationMessage) {
-    commentBody += count.toString() +
+    commentBody += count +
     '. ' + explanationMessage + '\n';
     count += 1;
   }
 
   if (checklistMessage) {
-    commentBody += count.toString() +
+    commentBody += count +
     '. ' + checklistMessage + '\n';
     count += 1;
   }
 
   if (proofOfChangesMessage) {
-    commentBody += count.toString() +
+    commentBody += count +
     '. ' + proofOfChangesMessage + '\n';
   }
 
@@ -286,6 +286,26 @@ const checkTemplate = async (context) => {
   commentBody += 'Thanks!';
 
   commentBody = commentBody.trim();
+  return commentBody;
+};
+
+
+/**
+ * This function creates comments in the issue.
+ *
+ * @param {import('probot').Context} context
+ */
+const checkTemplate = async (context) => {
+  /**
+   * @type {import('probot').Octokit.PullsGetResponse} pullRequest
+   */
+  const pullRequest = context.payload.pull_request;
+  const commentBody = generateComment(pullRequest);
+
+  if (!commentBody){
+    return;
+  }
+
   pingAndAssignUsers(
     context,
     pullRequest,

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -211,14 +211,14 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
   */
   const proofOfChangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
 
-  if (proofOfChcangesHeadingIndex !== -1) {
+  if (proofOfChangesHeadingIndex !== -1) {
     const nextHeadingIndex = pullRequest.body.indexOf(
       HEADING_START,
-      proofOfChcangesHeadingIndex + PROOF_TEXT.length
+      proofOfChangesHeadingIndex + PROOF_TEXT.length
     );
 
     let proofOfChangesSection = pullRequest.body.substring(
-      proofOfChcangesHeadingIndex,
+      proofOfChangesHeadingIndex,
       nextHeadingIndex
     );
 

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -245,7 +245,7 @@ const checkProofOfChanges = (pullRequest) => {
     return (
       'The proof that changes are correct has not been provided, ' +
       'please make sure to upload a image/video showing that the changes ' +
-      'are correct. Or include a sentence saying "No proof of changes' +
+      'are correct. Or include a sentence saying "No proof of changes ' +
       'needed because" and the reason why proof of changes ' +
       'cannot be provided.'
     );
@@ -319,4 +319,5 @@ const checkTemplate = async (context) => {
 
 module.exports = {
   checkTemplate,
+  generateComment,
 };

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -76,7 +76,7 @@ const checkPRExplanation = (pullRequest) => {
     if (explanation.includes(EXPLANATION_TEXT)) {
       // The user has not added the explanation.
       return (
-        'the body of this PR is missing the required description, ' +
+        'The body of this PR is missing the required description, ' +
         'please update the body with a description of what this PR does.'
       );
     }
@@ -84,7 +84,7 @@ const checkPRExplanation = (pullRequest) => {
   } else {
     // There is no overview section in the body of the PR.
     return (
-      'the body of this PR is missing the overview section, please ' +
+      'The body of this PR is missing the overview section, please ' +
       'update it to include the overview.'
     );
   }
@@ -153,9 +153,8 @@ const checkEssentialChecklist = (pullRequest) => {
       // Check if karma/linter check item is unchecked.
       if (item.toLowerCase().includes(KARMA_LINTER)) {
         // Karma and linter is unchecked.
-
         message +=
-          'the karma and linter checklist has not been checked, ' +
+          'The karma and linter checklist has not been checked, ' +
           'please make sure to run the frontend tests and lint tests before ' +
           'pushing. ';
       }
@@ -167,17 +166,10 @@ const checkEssentialChecklist = (pullRequest) => {
         const isPrFromFork =
           pullRequest.head.repo.full_name === pullRequest.base.repo.full_name;
         if (!pullRequest.maintainer_can_modify && !isPrFromFork) {
-          if (message) {
-            message +=
-              'The allow edits from maintainers checklist needs to ' +
-              'be ticked so that maintainers can rerun failed tests. ' +
-              'Endeavour to add this by ticking on the check box. ';
-          } else {
-            message +=
-              'the allow edits from maintainers checklist needs to ' +
-              'be ticked so that maintainers can rerun failed tests. ' +
-              'Endeavour to add this by ticking on the check box. ';
-          }
+          message +=
+            'The allow edits from maintainers checklist needs to ' +
+            'be ticked so that maintainers can rerun failed tests. ' +
+            'Endeavour to add this by ticking on the check box. ';
         }
       }
     });
@@ -185,7 +177,7 @@ const checkEssentialChecklist = (pullRequest) => {
     return message;
   } else {
     return (
-      'the body of this PR is missing the checklist section, please ' +
+      'The body of this PR is missing the checklist section, please ' +
       'update it to include the checklist.'
     );
   }
@@ -209,10 +201,10 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
     that the changes made in this PR work correctly.
     -->
     ![oppiabot-test](https://user-images.githubusercontent.com/30050862/
-      107972472-e970c400-6fd9-11eb-8f49-e6e2701adf1e.gif)
+      test.gif)
     (or)
     https://user-images.githubusercontent.com/30050862/
-      107972497-ef66a500-6fd9-11eb-861e-da566cfeb658.mp4
+      test.mp4
       */
   const proofOfChcangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
 
@@ -227,24 +219,19 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
       nextHeadingIndex
     );
 
-    console.log(proofOfChangesSection.includes(UPLOADED_MEDIA));
-
     var proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
-    console.log(proofLinks);
-    let message = '';
 
+    // Check if there are images/videos added in the section.
     if (!proofLinks){
-      message +=
-          'The proof that changes are correct has not been provided, ' +
-          'please make sure to upload a image/video showing that the changes ' +
-          'are correct. ';
-      console.log(message);
+      return (
+        'The proof that changes are correct has not been provided, ' +
+        'please make sure to upload a image/video showing that the changes ' +
+        'are correct. ');
     }
-
-    return message;
+    return '';
   } else {
     return (
-      'the body of this PR is missing the proof that changes ' +
+      'The body of this PR is missing the proof that changes ' +
       'are correct section, please update it to include the section.'
     );
   }
@@ -267,40 +254,6 @@ const checkTemplate = async (context) => {
   const checklistMessage = checkEssentialChecklist(pullRequest);
   const proofOfChangesMessage = checkProofThatChangesAreCorrect(pullRequest);
   let commentBody = '';
-  // if (explanationMessage && checklistMessage && proofOfChangesMessage) {
-  //   commentBody =
-  //     'Hi @' +
-  //     pullRequest.user.login +
-  //     ', ' +
-  //     explanationMessage +
-  //     '<br>Also, ' +
-  //     proofOfChangesMessage.trim() +
-  //     '<br>Also, ' +
-  //     checklistMessage.trim() +
-  //     ' Thanks!';
-  // } else if (explanationMessage) {
-  //   commentBody =
-  //     'Hi @' +
-  //     pullRequest.user.login +
-  //     ', ' +
-  //     explanationMessage +
-  //     ' Thanks!';
-  // } else if (checklistMessage) {
-  //   commentBody =
-  //     'Hi @' +
-  //     pullRequest.user.login +
-  //     ', ' +
-  //     checklistMessage.trim() +
-  //     ' Thanks!';
-  // } else if (proofOfChangesMessage){
-  //   'Hi @' +
-  //     pullRequest.user.login +
-  //     ', ' +
-  //     proofOfChangesMessage +
-  //     ' Thanks!';
-  // } else {
-  //   return;
-  // }
 
   count = 1;
 
@@ -329,6 +282,8 @@ const checkTemplate = async (context) => {
   if (commentBody === commentBodybasic){
     return;
   }
+
+  commentBody += 'Thanks!';
 
   commentBody = commentBody.trim();
   pingAndAssignUsers(

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -23,7 +23,8 @@ const EXPLANATION_TEXT = '[Explain here what your PR does and why]';
 const CHECKLIST_TEXT = '## Essential Checklist';
 const PROOF_TEXT = '## Proof that changes are correct';
 const UPLOADED_MEDIA = 'http';
-const PROOF_UNAVAILABLE_TEXT = 'No proof of changes needed because';
+const PROOF_UNAVAILABLE_TEXT =
+  /No\s*proof\s*of\s*changes\s*needed\s*because/mgi;
 // Add the "\r\n" in the regex for every new line.
 const PROOF_HTML_COMMENT = /<!--\r\n.*\r\n.*\r\n-->/;
 const EDITS_FROM_MAINTAINERS_TEXT = 'allow edits from maintainers';
@@ -224,8 +225,10 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
 
     const proofIsNotPossible = proofOfChangesSection.replace(
       PROOF_HTML_COMMENT, ''
-    ).includes(PROOF_UNAVAILABLE_TEXT);
-
+    ).match(PROOF_UNAVAILABLE_TEXT);
+    console.log(proofOfChangesSection.replace(
+      PROOF_HTML_COMMENT, ''
+    ).match(PROOF_UNAVAILABLE_TEXT));
     const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
     // Check if there are images/videos added in the section.

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -21,6 +21,8 @@ const { pingAndAssignUsers } = require('./utils');
 const KARMA_LINTER = 'linter/karma';
 const EXPLANATION_TEXT = '[Explain here what your PR does and why]';
 const CHECKLIST_TEXT = '## Essential Checklist';
+const PROOF_TEXT = '## Proof that changes are correct';
+const UPLOADED_MEDIA = 'user-images.githubusercontent.com';
 const EDITS_FROM_MAINTAINERS_TEXT = 'allow edits from maintainers';
 const UNCHECKED_CHECKLIST = '- [ ]';
 const EXPLANATION_START = '2';
@@ -189,6 +191,66 @@ const checkEssentialChecklist = (pullRequest) => {
   }
 };
 
+
+/**
+ * This function checks if the pull request's body contains the
+ * checklist and returns an appropriate message if the required
+ * checklist items are not checked.
+ *
+ * @param {import('probot').Octokit.PullsGetResponse} pullRequest
+ */
+const checkProofThatChangesAreCorrect = (pullRequest) => {
+  /*
+    A valid Proof that changes are correct section would look like:
+    ## Proof that changes are correct
+
+    <!--
+    Add videos/screenshots of the user-facing interface to demonstrate
+    that the changes made in this PR work correctly.
+    -->
+    ![oppiabot-test](https://user-images.githubusercontent.com/30050862/
+      107972472-e970c400-6fd9-11eb-8f49-e6e2701adf1e.gif)
+    (or)
+    https://user-images.githubusercontent.com/30050862/
+      107972497-ef66a500-6fd9-11eb-861e-da566cfeb658.mp4
+      */
+  const proofOfChcangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
+
+  if (proofOfChcangesHeadingIndex !== -1) {
+    const nextHeadingIndex = pullRequest.body.indexOf(
+      HEADING_START,
+      proofOfChcangesHeadingIndex + PROOF_TEXT.length
+    );
+
+    let proofOfChangesSection = pullRequest.body.substring(
+      proofOfChcangesHeadingIndex,
+      nextHeadingIndex
+    );
+
+    console.log(proofOfChangesSection.includes(UPLOADED_MEDIA));
+
+    var proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
+    console.log(proofLinks);
+    let message = '';
+
+    if (!proofLinks){
+      message +=
+          'The proof that changes are correct has not been provided, ' +
+          'please make sure to upload a image/video showing that the changes ' +
+          'are correct. ';
+      console.log(message);
+    }
+
+    return message;
+  } else {
+    return (
+      'the body of this PR is missing the proof that changes ' +
+      'are correct section, please update it to include the section.'
+    );
+  }
+};
+
+
 /**
  * This function checks that a PR follows the appropriate template and
  * comments on the PR if key parts of the template is missing.
@@ -203,34 +265,72 @@ const checkTemplate = async (context) => {
 
   const explanationMessage = checkPRExplanation(pullRequest);
   const checklistMessage = checkEssentialChecklist(pullRequest);
+  const proofOfChangesMessage = checkProofThatChangesAreCorrect(pullRequest);
   let commentBody = '';
-  if (explanationMessage && checklistMessage) {
-    commentBody =
+  // if (explanationMessage && checklistMessage && proofOfChangesMessage) {
+  //   commentBody =
+  //     'Hi @' +
+  //     pullRequest.user.login +
+  //     ', ' +
+  //     explanationMessage +
+  //     '<br>Also, ' +
+  //     proofOfChangesMessage.trim() +
+  //     '<br>Also, ' +
+  //     checklistMessage.trim() +
+  //     ' Thanks!';
+  // } else if (explanationMessage) {
+  //   commentBody =
+  //     'Hi @' +
+  //     pullRequest.user.login +
+  //     ', ' +
+  //     explanationMessage +
+  //     ' Thanks!';
+  // } else if (checklistMessage) {
+  //   commentBody =
+  //     'Hi @' +
+  //     pullRequest.user.login +
+  //     ', ' +
+  //     checklistMessage.trim() +
+  //     ' Thanks!';
+  // } else if (proofOfChangesMessage){
+  //   'Hi @' +
+  //     pullRequest.user.login +
+  //     ', ' +
+  //     proofOfChangesMessage +
+  //     ' Thanks!';
+  // } else {
+  //   return;
+  // }
+
+  count = 1;
+
+  commentBodybasic = commentBody =
       'Hi @' +
       pullRequest.user.login +
-      ', ' +
-      explanationMessage +
-      '<br>Also, ' +
-      checklistMessage.trim() +
-      ' Thanks!';
-  } else if (explanationMessage) {
-    commentBody =
-      'Hi @' +
-      pullRequest.user.login +
-      ', ' +
-      explanationMessage +
-      ' Thanks!';
-  } else if (checklistMessage) {
-    commentBody =
-      'Hi @' +
-      pullRequest.user.login +
-      ', ' +
-      checklistMessage.trim() +
-      ' Thanks!';
-  } else {
+      ', can you complete the following:\n';
+
+  if (explanationMessage) {
+    commentBody += count.toString() +
+    '. ' + explanationMessage + '\n';
+    count += 1;
+  }
+
+  if (checklistMessage) {
+    commentBody += count.toString() +
+    '. ' + checklistMessage + '\n';
+    count += 1;
+  }
+
+  if (proofOfChangesMessage) {
+    commentBody += count.toString() +
+    '. ' + proofOfChangesMessage + '\n';
+  }
+
+  if (commentBody === commentBodybasic){
     return;
   }
 
+  commentBody = commentBody.trim();
   pingAndAssignUsers(
     context,
     pullRequest,

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -208,8 +208,8 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
     (or)
     https://user-images.githubusercontent.com/30050862/
       test.mp4
-      */
-  const proofOfChcangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
+  */
+  const proofOfChangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
 
   if (proofOfChcangesHeadingIndex !== -1) {
     const nextHeadingIndex = pullRequest.body.indexOf(
@@ -222,8 +222,9 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
       nextHeadingIndex
     );
 
-    const proofUnavailable = proofOfChangesSection
-      .replace(PROOF_HTML_COMMENT, '').includes(PROOF_UNAVAILABLE_TEXT);
+    const proofIsNotPossible = proofOfChangesSection.replace(
+      PROOF_HTML_COMMENT, ''
+    ).includes(PROOF_UNAVAILABLE_TEXT);
 
     const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
@@ -232,7 +233,8 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
       return (
         'The proof that changes are correct has not been provided, ' +
         'please make sure to upload a image/video showing that the changes ' +
-        'are correct. ');
+        'are correct.'
+      );
     }
     return '';
   } else {

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -197,18 +197,23 @@ const checkEssentialChecklist = (pullRequest) => {
  */
 const checkProofThatChangesAreCorrect = (pullRequest) => {
   /*
-    A valid Proof that changes are correct section would look like:
-    ## Proof that changes are correct
+    A valid 'Proof that changes are correct' section would either:
+      1. Contain a link to some image or video that contains the proof.
+        ## Proof that changes are correct
 
-    <!--
-    Add videos/screenshots of the user-facing interface to demonstrate
-    that the changes made in this PR work correctly.
-    -->
-    ![oppiabot-test](https://user-images.githubusercontent.com/30050862/
-      test.gif)
-    (or)
-    https://user-images.githubusercontent.com/30050862/
-      test.mp4
+        <!--
+        Add videos/screenshots of the user-facing interface to demonstrate
+        that the changes made in this PR work correctly.
+        -->
+        https://user-images.githubusercontent.com/30050862/test.mp4
+      2. Contain a text saying 'No proof of changes needed because …'
+        ## Proof that changes are correct
+
+        <!--
+        Add videos/screenshots of the user-facing interface to demonstrate
+        that the changes made in this PR work correctly.
+        -->
+        No proof of changes needed because {{reason}}.
   */
   const proofOfChangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
 
@@ -232,11 +237,13 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
     const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
     // Check if there are images/videos added in the section.
-    if (!proofLinks && !proofIsNotPossible){
+    if (!proofLinks && !proofIsNotPossible) {
       return (
         'The proof that changes are correct has not been provided, ' +
         'please make sure to upload a image/video showing that the changes ' +
-        'are correct.'
+        'are correct. Or include a sentence saying "No proof of changes' +
+        'needed because" and the reason why proof of changes ' +
+        'cannot be provided.'
       );
     }
     return '';
@@ -258,40 +265,35 @@ const generateComment = (pullRequest) => {
   const explanationMessage = checkPRExplanation(pullRequest);
   const checklistMessage = checkEssentialChecklist(pullRequest);
   const proofOfChangesMessage = checkProofThatChangesAreCorrect(pullRequest);
-  let commentBody = '';
 
-  var count = 1;
+  let count = 1;
 
-  var commentBodybasic = commentBody =
-      'Hi @' +
-      pullRequest.user.login +
-      ', can you complete the following:\n';
+  let commentBody = (
+    'Hi @' + pullRequest.user.login + ', can you complete the following:\n');
 
   if (explanationMessage) {
-    commentBody += count +
-    '. ' + explanationMessage + '\n';
+    commentBody += count + '. ' + explanationMessage + '\n';
     count += 1;
   }
 
   if (checklistMessage) {
-    commentBody += count +
-    '. ' + checklistMessage + '\n';
+    commentBody += count + '. ' + checklistMessage + '\n';
     count += 1;
   }
 
   if (proofOfChangesMessage) {
-    commentBody += count +
-    '. ' + proofOfChangesMessage + '\n';
+    commentBody += count + '. ' + proofOfChangesMessage + '\n';
+    count += 1;
   }
 
-  if (commentBody === commentBodybasic){
+  // If there is no reason to produce the message do not return anything.
+  if (count === 1) {
     return;
   }
 
   commentBody += 'Thanks!';
 
-  commentBody = commentBody.trim();
-  return commentBody;
+  return commentBody.trim();
 };
 
 
@@ -307,7 +309,7 @@ const checkTemplate = async (context) => {
   const pullRequest = context.payload.pull_request;
   const commentBody = generateComment(pullRequest);
 
-  if (!commentBody){
+  if (!commentBody) {
     return;
   }
 

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -217,42 +217,42 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
   */
   const proofOfChangesHeadingIndex = pullRequest.body.indexOf(PROOF_TEXT);
 
-  if (proofOfChangesHeadingIndex !== -1) {
-    const nextHeadingIndex = pullRequest.body.indexOf(
-      HEADING_START,
-      proofOfChangesHeadingIndex + PROOF_TEXT.length
-    );
-
-    let proofOfChangesSection = pullRequest.body.substring(
-      proofOfChangesHeadingIndex,
-      nextHeadingIndex
-    );
-
-    const proofIsNotPossible = proofOfChangesSection.replace(
-      PROOF_HTML_COMMENT, ''
-    ).match(PROOF_UNAVAILABLE_TEXT);
-    console.log(proofOfChangesSection.replace(
-      PROOF_HTML_COMMENT, ''
-    ).match(PROOF_UNAVAILABLE_TEXT));
-    const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
-
-    // Check if there are images/videos added in the section.
-    if (!proofLinks && !proofIsNotPossible) {
-      return (
-        'The proof that changes are correct has not been provided, ' +
-        'please make sure to upload a image/video showing that the changes ' +
-        'are correct. Or include a sentence saying "No proof of changes' +
-        'needed because" and the reason why proof of changes ' +
-        'cannot be provided.'
-      );
-    }
-    return '';
-  } else {
+  if (proofOfChangesHeadingIndex === -1) {
     return (
       'The body of this PR is missing the proof that changes ' +
       'are correct section, please update it to include the section.'
     );
   }
+
+  const nextHeadingIndex = pullRequest.body.indexOf(
+    HEADING_START,
+    proofOfChangesHeadingIndex + PROOF_TEXT.length
+  );
+
+  let proofOfChangesSection = pullRequest.body.substring(
+    proofOfChangesHeadingIndex,
+    nextHeadingIndex
+  );
+
+  const proofIsNotPossible = proofOfChangesSection.replace(
+    PROOF_HTML_COMMENT, ''
+  ).match(PROOF_UNAVAILABLE_TEXT);
+  console.log(proofOfChangesSection.replace(
+    PROOF_HTML_COMMENT, ''
+  ).match(PROOF_UNAVAILABLE_TEXT));
+  const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
+
+  // Check if there are images/videos added in the section.
+  if (!proofLinks && !proofIsNotPossible) {
+    return (
+      'The proof that changes are correct has not been provided, ' +
+      'please make sure to upload a image/video showing that the changes ' +
+      'are correct. Or include a sentence saying "No proof of changes' +
+      'needed because" and the reason why proof of changes ' +
+      'cannot be provided.'
+    );
+  }
+  return '';
 };
 
 /**

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -22,8 +22,8 @@ const KARMA_LINTER = 'linter/karma';
 const EXPLANATION_TEXT = '[Explain here what your PR does and why]';
 const CHECKLIST_TEXT = '## Essential Checklist';
 const PROOF_TEXT = '## Proof that changes are correct';
-const UPLOADED_MEDIA = 'http';
-const PROOF_UNAVAILABLE_TEXT =
+const UPLOADED_MEDIA_TEXT = 'http';
+const PROOF_UNAVAILABLE_REGEX =
   /No\s*proof\s*of\s*changes\s*needed\s*because/mgi;
 // Add the "\r\n" in the regex for every new line.
 const PROOF_HTML_COMMENT = /<!--\r\n.*\r\n.*\r\n-->/;
@@ -236,9 +236,9 @@ const checkProofOfChanges = (pullRequest) => {
 
   const proofIsNotPossible = proofOfChangesSection.replace(
     PROOF_HTML_COMMENT, ''
-  ).match(PROOF_UNAVAILABLE_TEXT);
+  ).match(PROOF_UNAVAILABLE_REGEX);
 
-  const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
+  const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA_TEXT);
 
   // Check if there are images/videos added in the section.
   if (!proofLinks && !proofIsNotPossible) {

--- a/lib/checkPullRequestTemplate.js
+++ b/lib/checkPullRequestTemplate.js
@@ -229,7 +229,7 @@ const checkProofThatChangesAreCorrect = (pullRequest) => {
     const proofLinks = proofOfChangesSection.includes(UPLOADED_MEDIA);
 
     // Check if there are images/videos added in the section.
-    if (!proofLinks && !proofUnavailable){
+    if (!proofLinks && !proofIsNotPossible){
       return (
         'The proof that changes are correct has not been provided, ' +
         'please make sure to upload a image/video showing that the changes ' +

--- a/spec/checkPullRequestTemplateSpec.js
+++ b/spec/checkPullRequestTemplateSpec.js
@@ -249,7 +249,7 @@ describe('Pull Request Template', () => {
   const incompleteProofOfChangesSection =
     'The proof that changes are correct has not been provided, ' +
     'please make sure to upload a image/video showing that the changes ' +
-    'are correct. ';
+    'are correct.';
 
   const absentProofOfChangesSection =
     'The body of this PR is missing the proof that changes ' +

--- a/spec/checkPullRequestTemplateSpec.js
+++ b/spec/checkPullRequestTemplateSpec.js
@@ -248,7 +248,7 @@ describe('Pull Request Template', () => {
   const incompleteProofOfChangesSection =
     'The proof that changes are correct has not been provided, ' +
     'please make sure to upload a image/video showing that the changes ' +
-    'are correct. Or include a sentence saying "No proof of changes' +
+    'are correct. Or include a sentence saying "No proof of changes ' +
     'needed because" and the reason why proof of changes ' +
     'cannot be provided.';
 
@@ -661,4 +661,50 @@ describe('Pull Request Template', () => {
       });
     });
   });
+
+  describe('testing generateComment function with bodyWithInvalidTemplate',
+    () => {
+      it('should return comment for bodyWithInvalidTemplate', () => {
+        const payloadData = JSON.parse(
+          JSON.stringify(require('../fixtures/pullRequestPayload.json'))
+        );
+        payloadData.payload.pull_request.body = bodyWithInvalidTemplate;
+        payloadData.payload.pull_request.maintainer_can_modify = false;
+        spyOn(checkPullRequestTemplateModule, 'generateComment')
+          .and.callThrough();
+        expect(
+          checkPullRequestTemplateModule.generateComment(
+            payloadData.payload.pull_request)).toBe(
+          'Hi @' +
+          payloadData.payload.pull_request.user.login +
+          ', can you complete the following:' + '\n' +
+          '1. ' + incompleteOverviewSection + '\n' +
+          '2. ' + incompleteChecklistSection.karma_linter +
+          incompleteChecklistSection.maintainers_text + '\n' +
+          '3. ' + incompleteProofOfChangesSection + '\nThanks!');
+      });
+    });
+
+  describe('testing generateComment function with bodyWithInvalidTemplate',
+    () => {
+      it('should return comment for bodyWithInvalidTemplate', () => {
+        const payloadData = JSON.parse(
+          JSON.stringify(require('../fixtures/pullRequestPayload.json'))
+        );
+        payloadData.payload.pull_request.body = bodyWithNoOverview;
+        payloadData.payload.pull_request.maintainer_can_modify = false;
+        spyOn(checkPullRequestTemplateModule, 'generateComment')
+          .and.callThrough();
+        expect(
+          checkPullRequestTemplateModule.generateComment(
+            payloadData.payload.pull_request)).toBe(
+          'Hi @' +
+          payloadData.payload.pull_request.user.login +
+          ', can you complete the following:' + '\n' +
+          '1. ' + absentOverviewSection + '\n' +
+          '2. ' + incompleteChecklistSection.karma_linter +
+          incompleteChecklistSection.maintainers_text + '\n' +
+          '3. ' + incompleteProofOfChangesSection + '\nThanks!');
+      });
+    });
 });

--- a/spec/checkPullRequestTemplateSpec.js
+++ b/spec/checkPullRequestTemplateSpec.js
@@ -52,6 +52,7 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -70,6 +71,7 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -79,6 +81,29 @@ describe('Pull Request Template', () => {
     '1. This PR fixes or fixes part of #[fill_in_number_here].\r\n' +
     '2. This PR does the following: [Explain here what your PR ' +
     'does and why]\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
+    '## PR Pointers\r\n\r\n' +
+    '- Oppiabot will ' +
+    "notify you when you don't add a PR_CHANGELOG label.";
+
+  const bodyWithNoProofOfChangesSection =
+  '## Overview\r\n' +
+    '1. This PR fixes or fixes part of #[fill_in_number_here].\r\n' +
+    '2. This PR does the following: [Explain here what your PR ' +
+    'does and why]\r\n\r\n' +
+    '## Essential Checklist\r\n\r\n' +
+    '- [ ] The PR title starts with "Fix #bugnum: ", followed by a short' +
+    ', clear summary of the changes. (If this PR fixes part of an issue, ' +
+    'prefix the title with "Fix part of #bugnum: ...".)\r\n' +
+    '- [ ] The linter/Karma presubmit checks have passed locally on ' +
+    'your machine.\r\n' +
+    '- [ ] "Allow edits from maintainers" is checked. (See [here]' +
+    '(https://help.github.com/en/github/collaborating-with-issues-and' +
+    '-pull-requests/allowing-changes-to-a-pull-request-branch-created-' +
+    'from-a-fork) for instructions on how to enable it.)\r\n  - This ' +
+    'lets reviewers restart your CircleCI tests for you.\r\n' +
+    "- [ ] The PR is made from a branch that's **not** called " +
+    '"develop".\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -101,6 +126,7 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -123,6 +149,30 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
+    '## PR Pointers\r\n\r\n' +
+    '- Oppiabot will ' +
+    "notify you when you don't add a PR_CHANGELOG label.";
+
+  const bodyWithExplanationAndChecklist =
+  ' ## Overview\r\n' +
+    '1. This PR fixes or fixes part of #[fill_in_number_here].\r\n' +
+    '2. This PR does the following: This PR does a bunch of things. ' +
+    '\r\n\r\n' +
+    '## Essential Checklist\r\n\r\n' +
+    '- [ ] The PR title starts with "Fix #bugnum: ", followed by a short' +
+    ', clear summary of the changes. (If this PR fixes part of an issue, ' +
+    'prefix the title with "Fix part of #bugnum: ...".)\r\n' +
+    '- [x] The linter/Karma presubmit checks have passed locally on ' +
+    'your machine.\r\n' +
+    '- [x] "Allow edits from maintainers" is checked. (See [here]' +
+    '(https://help.github.com/en/github/collaborating-with-issues-and' +
+    '-pull-requests/allowing-changes-to-a-pull-request-branch-created-' +
+    'from-a-fork) for instructions on how to enable it.)\r\n  - This ' +
+    'lets reviewers restart your CircleCI tests for you.\r\n' +
+    "- [ ] The PR is made from a branch that's **not** called " +
+    '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -145,6 +195,7 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
@@ -167,9 +218,42 @@ describe('Pull Request Template', () => {
     'lets reviewers restart your CircleCI tests for you.\r\n' +
     "- [ ] The PR is made from a branch that's **not** called " +
     '"develop".\r\n\r\n' +
+    '## Proof that changes are correct\r\n\r\n' +
+    'https://user-images.githubusercontent.com/30050862/test.mp4' +
     '## PR Pointers\r\n\r\n' +
     '- Oppiabot will ' +
     "notify you when you don't add a PR_CHANGELOG label.";
+
+  const incompleteOverviewSection =
+    'The body of this PR is missing the required description, ' +
+    'please update the body with a description of what this PR does.';
+
+  const absentOverviewSection =
+    'The body of this PR is missing the overview section, please ' +
+    'update it to include the overview.';
+
+  const incompleteChecklistSection1 =
+    'The karma and linter checklist has not been checked, ' +
+    'please make sure to run the frontend tests and lint tests before ' +
+    'pushing. ';
+
+  const incompleteChecklistSection2 =
+    'The allow edits from maintainers checklist needs to ' +
+    'be ticked so that maintainers can rerun failed tests. ' +
+    'Endeavour to add this by ticking on the check box. ';
+
+  const absentChecklistSection =
+    'The body of this PR is missing the checklist section, please ' +
+    'update it to include the checklist.';
+
+  const incompleteProofOfChangesSection =
+    'The proof that changes are correct has not been provided, ' +
+    'please make sure to upload a image/video showing that the changes ' +
+    'are correct. ';
+
+  const absentProofOfChangesSection =
+    'The body of this PR is missing the proof that changes ' +
+    'are correct section, please update it to include the section.';
 
   /**
    * @type {import('probot').Probot} robot
@@ -240,13 +324,10 @@ describe('Pull Request Template', () => {
         body:
           'Hi @' +
           payloadData.payload.pull_request.user.login +
-          ', the body of this PR is missing the required description, ' +
-          'please update the body with a description of what this PR does.' +
-          '<br>Also, the karma and linter checklist has not been checked, ' +
-          'please make sure to run the frontend tests and lint tests before ' +
-          'pushing. The allow edits from maintainers checklist needs to ' +
-          'be ticked so that maintainers can rerun failed tests. Endeavour ' +
-          'to add this by ticking on the check box. Thanks!',
+          ', can you complete the following:' + '\n' +
+          '1. ' + incompleteOverviewSection + '\n' +
+          '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
+          '\n' + '3. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -281,13 +362,10 @@ describe('Pull Request Template', () => {
         body:
           'Hi @' +
           payloadData.payload.pull_request.user.login +
-          ', the body of this PR is missing the overview section, please ' +
-          'update it to include the overview.<br>' +
-          'Also, the karma and linter checklist has not been checked, ' +
-          'please make sure to run the frontend tests and lint tests before ' +
-          'pushing. The allow edits from maintainers checklist needs to ' +
-          'be ticked so that maintainers can rerun failed tests. Endeavour ' +
-          'to add this by ticking on the check box. Thanks!',
+          ', can you complete the following:' + '\n' +
+          '1. ' + absentOverviewSection + '\n' +
+          '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
+          '\n' + '3. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -320,12 +398,51 @@ describe('Pull Request Template', () => {
         repo: payloadData.payload.repository.name,
         owner: payloadData.payload.repository.owner.login,
         body:
-          'Hi @' +
-          payloadData.payload.pull_request.user.login +
-          ', the body of this PR is missing the required description, ' +
-          'please update the body with a description of what this PR does.' +
-          '<br>Also, the body of this PR is missing the checklist section, ' +
-          'please update it to include the checklist. Thanks!',
+        'Hi @' +
+        payloadData.payload.pull_request.user.login +
+        ', can you complete the following:' + '\n' +
+        '1. ' + incompleteOverviewSection + '\n' +
+        '2. ' + absentChecklistSection +
+        '\n' + '3. ' + incompleteProofOfChangesSection + '\nThanks!',
+      });
+    });
+
+    it('should assign PR author', () => {
+      expect(github.issues.addAssignees).toHaveBeenCalled();
+      expect(github.issues.addAssignees).toHaveBeenCalledWith({
+        issue_number: payloadData.payload.pull_request.number,
+        repo: payloadData.payload.repository.name,
+        owner: payloadData.payload.repository.owner.login,
+        assignees: [payloadData.payload.pull_request.user.login],
+      });
+    });
+  });
+
+  describe('when pull request with no Proof of changes section ' +
+  'is created', () => {
+    beforeEach(async () => {
+      payloadData.payload.pull_request.body = bodyWithNoProofOfChangesSection;
+      payloadData.payload.pull_request.maintainer_can_modify = false;
+      await robot.receive(payloadData);
+    });
+
+    it('should check the template', () => {
+      expect(checkPullRequestTemplateModule.checkTemplate).toHaveBeenCalled();
+    });
+
+    it('should ping PR author', () => {
+      expect(github.issues.createComment).toHaveBeenCalled();
+      expect(github.issues.createComment).toHaveBeenCalledWith({
+        issue_number: payloadData.payload.pull_request.number,
+        repo: payloadData.payload.repository.name,
+        owner: payloadData.payload.repository.owner.login,
+        body:
+        'Hi @' +
+        payloadData.payload.pull_request.user.login +
+        ', can you complete the following:' + '\n' +
+        '1. ' + incompleteOverviewSection + '\n' +
+        '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
+        '\n' + '3. ' + absentProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -358,13 +475,11 @@ describe('Pull Request Template', () => {
         repo: payloadData.payload.repository.name,
         owner: payloadData.payload.repository.owner.login,
         body:
-          'Hi @' +
-          payloadData.payload.pull_request.user.login +
-          ', the karma and linter checklist has not been checked, ' +
-          'please make sure to run the frontend tests and lint tests before ' +
-          'pushing. The allow edits from maintainers checklist needs to ' +
-          'be ticked so that maintainers can rerun failed tests. Endeavour ' +
-          'to add this by ticking on the check box. Thanks!',
+        'Hi @' +
+        payloadData.payload.pull_request.user.login +
+        ', can you complete the following:' + '\n' +
+        '1. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
+        '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -398,10 +513,48 @@ describe('Pull Request Template', () => {
           repo: payloadData.payload.repository.name,
           owner: payloadData.payload.repository.owner.login,
           body:
-            'Hi @' + payloadData.payload.pull_request.user.login +
-            ', the allow edits from maintainers checklist needs to ' +
-            'be ticked so that maintainers can rerun failed tests. Endeavour ' +
-            'to add this by ticking on the check box. Thanks!',
+          'Hi @' +
+          payloadData.payload.pull_request.user.login +
+          ', can you complete the following:' + '\n' +
+          '1. ' + incompleteChecklistSection2 +
+          '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
+        });
+      });
+
+      it('should assign PR author', () => {
+        expect(github.issues.addAssignees).toHaveBeenCalled();
+        expect(github.issues.addAssignees).toHaveBeenCalledWith({
+          issue_number: payloadData.payload.pull_request.number,
+          repo: payloadData.payload.repository.name,
+          owner: payloadData.payload.repository.owner.login,
+          assignees: [payloadData.payload.pull_request.user.login],
+        });
+      });
+    });
+
+  describe('when pull request contains description and filled Checklist',
+    () => {
+      beforeEach(async () => {
+        payloadData.payload.pull_request.body = bodyWithExplanationAndChecklist;
+        payloadData.payload.pull_request.maintainer_can_modify = false;
+        await robot.receive(payloadData);
+      });
+
+      it('should check the template', () => {
+        expect(checkPullRequestTemplateModule.checkTemplate).toHaveBeenCalled();
+      });
+
+      it('should ping PR author', () => {
+        expect(github.issues.createComment).toHaveBeenCalled();
+        expect(github.issues.createComment).toHaveBeenCalledWith({
+          issue_number: payloadData.payload.pull_request.number,
+          repo: payloadData.payload.repository.name,
+          owner: payloadData.payload.repository.owner.login,
+          body:
+          'Hi @' +
+          payloadData.payload.pull_request.user.login +
+          ', can you complete the following:' + '\n' +
+          '1. ' + incompleteProofOfChangesSection + '\nThanks!',
         });
       });
 
@@ -436,10 +589,11 @@ describe('Pull Request Template', () => {
           repo: payloadData.payload.repository.name,
           owner: payloadData.payload.repository.owner.login,
           body:
-            'Hi @' + payloadData.payload.pull_request.user.login +
-            ', the body of this PR is missing the required description, ' +
-            'please update the body with a description of what this PR does. ' +
-            'Thanks!',
+          'Hi @' +
+          payloadData.payload.pull_request.user.login +
+          ', can you complete the following:' + '\n' +
+          '1. ' + incompleteOverviewSection +
+          '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
         });
       });
 
@@ -494,11 +648,11 @@ describe('Pull Request Template', () => {
         repo: payloadData.payload.repository.name,
         owner: payloadData.payload.repository.owner.login,
         body:
-          'Hi @' +
-          payloadData.payload.pull_request.user.login +
-          ', the karma and linter checklist has not been checked, ' +
-          'please make sure to run the frontend tests and lint tests ' +
-          'before pushing. Thanks!',
+        'Hi @' +
+        payloadData.payload.pull_request.user.login +
+        ', can you complete the following:' + '\n' +
+        '1. ' + incompleteChecklistSection1 +
+        '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
   });

--- a/spec/checkPullRequestTemplateSpec.js
+++ b/spec/checkPullRequestTemplateSpec.js
@@ -232,15 +232,14 @@ describe('Pull Request Template', () => {
     'The body of this PR is missing the overview section, please ' +
     'update it to include the overview.';
 
-  const incompleteChecklistSection1 =
-    'The karma and linter checklist has not been checked, ' +
-    'please make sure to run the frontend tests and lint tests before ' +
-    'pushing. ';
-
-  const incompleteChecklistSection2 =
-    'The allow edits from maintainers checklist needs to ' +
-    'be ticked so that maintainers can rerun failed tests. ' +
-    'Endeavour to add this by ticking on the check box. ';
+  const incompleteChecklistSection = {
+    karma_linter: 'The karma and linter checklist has not been checked, ' +
+      'please make sure to run the frontend tests and lint tests before ' +
+      'pushing. ',
+    maintainers_text: 'The allow edits from maintainers checklist needs to ' +
+      'be ticked so that maintainers can rerun failed tests. ' +
+      'Endeavour to add this by ticking on the check box. '
+  };
 
   const absentChecklistSection =
     'The body of this PR is missing the checklist section, please ' +
@@ -249,7 +248,9 @@ describe('Pull Request Template', () => {
   const incompleteProofOfChangesSection =
     'The proof that changes are correct has not been provided, ' +
     'please make sure to upload a image/video showing that the changes ' +
-    'are correct.';
+    'are correct. Or include a sentence saying "No proof of changes' +
+    'needed because" and the reason why proof of changes ' +
+    'cannot be provided.';
 
   const absentProofOfChangesSection =
     'The body of this PR is missing the proof that changes ' +
@@ -326,8 +327,9 @@ describe('Pull Request Template', () => {
           payloadData.payload.pull_request.user.login +
           ', can you complete the following:' + '\n' +
           '1. ' + incompleteOverviewSection + '\n' +
-          '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
-          '\n' + '3. ' + incompleteProofOfChangesSection + '\nThanks!',
+          '2. ' + incompleteChecklistSection.karma_linter +
+          incompleteChecklistSection.maintainers_text + '\n' +
+          '3. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -364,8 +366,9 @@ describe('Pull Request Template', () => {
           payloadData.payload.pull_request.user.login +
           ', can you complete the following:' + '\n' +
           '1. ' + absentOverviewSection + '\n' +
-          '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
-          '\n' + '3. ' + incompleteProofOfChangesSection + '\nThanks!',
+          '2. ' + incompleteChecklistSection.karma_linter +
+          incompleteChecklistSection.maintainers_text + '\n' +
+          '3. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -441,8 +444,9 @@ describe('Pull Request Template', () => {
         payloadData.payload.pull_request.user.login +
         ', can you complete the following:' + '\n' +
         '1. ' + incompleteOverviewSection + '\n' +
-        '2. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
-        '\n' + '3. ' + absentProofOfChangesSection + '\nThanks!',
+        '2. ' + incompleteChecklistSection.karma_linter +
+        incompleteChecklistSection.maintainers_text + '\n' +
+        '3. ' + absentProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -478,8 +482,9 @@ describe('Pull Request Template', () => {
         'Hi @' +
         payloadData.payload.pull_request.user.login +
         ', can you complete the following:' + '\n' +
-        '1. ' + incompleteChecklistSection1 + incompleteChecklistSection2 +
-        '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
+        '1. ' + incompleteChecklistSection.karma_linter +
+        incompleteChecklistSection.maintainers_text + '\n' +
+        '2. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });
 
@@ -516,7 +521,7 @@ describe('Pull Request Template', () => {
           'Hi @' +
           payloadData.payload.pull_request.user.login +
           ', can you complete the following:' + '\n' +
-          '1. ' + incompleteChecklistSection2 +
+          '1. ' + incompleteChecklistSection.maintainers_text +
           '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
         });
       });
@@ -651,7 +656,7 @@ describe('Pull Request Template', () => {
         'Hi @' +
         payloadData.payload.pull_request.user.login +
         ', can you complete the following:' + '\n' +
-        '1. ' + incompleteChecklistSection1 +
+        '1. ' + incompleteChecklistSection.karma_linter +
         '\n' + '2. ' + incompleteProofOfChangesSection + '\nThanks!',
       });
     });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
  Fixes #178 
  
  The function checks for the presence of `user-images.githubusercontent.com` since that's where all the images/videos are uploaded.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
