### PR TITLE
Fix #195: Expose simple way to generate sheets token

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -4,6 +4,5 @@
   "functions": 100,
   "statements": 100,
   "check-coverage": true,
-  "reporter": ["lcov", "text"],
-  "exclude": ["./sheetsSetup.js"]
+  "reporter": ["lcov", "text"]
 }

--- a/.nycrc
+++ b/.nycrc
@@ -4,5 +4,6 @@
   "functions": 100,
   "statements": 100,
   "check-coverage": true,
-  "reporter": ["lcov", "text"]
+  "reporter": ["lcov", "text"],
+  "exclude": ["./sheetsSetup.js"]
 }

--- a/constants.js
+++ b/constants.js
@@ -62,7 +62,7 @@ const checksWhitelist = {
     [editEvent]: [],
     [issuesLabelEvent]: []
   },
-  'oppia': {
+  oppia: {
     [openEvent]: [
       claCheck,
       changelogCheck,
@@ -100,7 +100,7 @@ const checksWhitelist = {
     [checkCompletedEvent]: [ciFailureCheck],
     [issueCommentCreatedEvent]: [respondToReviewCheck]
   },
-  'oppiabot': {
+  oppiabot: {
     [openEvent]: [claCheck],
     [reopenEvent]: [],
     [synchronizeEvent]: [mergeConflictCheck],

--- a/lib/apiForSheets.js
+++ b/lib/apiForSheets.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // Google Sheets API v4
-const fs = require('fs');
 const readline = require('readline');
 const { google } = require('googleapis');
 const { OAuth2Client } = require('google-auth-library');
@@ -169,3 +168,35 @@ module.exports.checkClaStatus = async function (contextData) {
   // Call the sheets API with the authorized client.
   module.exports.checkClaSheet(oauthClient);
 };
+
+
+/**
+ * Get and store new token after prompting for user authorization, and then
+ * execute the given callback with the authorized OAuth2 client.
+ * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
+ * @param {getEventsCallback} callback The callback for the authorized client.
+ */
+module.exports.getNewToken = (oAuth2Client, callback) => {
+  const authUrl = oAuth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+  });
+  console.log('Authorize this app by visiting this url:', authUrl);
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  rl.question('Enter the code from that page here: ', (code) => {
+    rl.close();
+    oAuth2Client.getToken(code, (err, token) => {
+      if (err) {
+        return console.error(
+          'Error while trying to retrieve access token', err
+        );
+      }
+      oAuth2Client.setCredentials(token);
+      callback(token);
+    });
+  });
+};
+

--- a/lib/apiForSheets.js
+++ b/lib/apiForSheets.js
@@ -13,16 +13,11 @@
 // limitations under the License.
 
 // Google Sheets API v4
-const readline = require('readline');
 const { google } = require('googleapis');
 const { OAuth2Client } = require('google-auth-library');
 const claLabel = "PR: don't merge - NEEDS CLA";
-const claLabelArray = [claLabel];
 var spreadsheetId = process.env.SPREADSHEET_ID;
 
-// If modifying these scopes, delete your previously saved credentials
-// at ~/.credentials/sheets.googleapis.com-nodejs-quickstart.json
-var SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
 var clientSecret = process.env.CLIENT_SECRET;
 
 /**
@@ -168,35 +163,3 @@ module.exports.checkClaStatus = async function (contextData) {
   // Call the sheets API with the authorized client.
   module.exports.checkClaSheet(oauthClient);
 };
-
-
-/**
- * Get and store new token after prompting for user authorization, and then
- * execute the given callback with the authorized OAuth2 client.
- * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
- * @param {getEventsCallback} callback The callback for the authorized client.
- */
-module.exports.getNewToken = (oAuth2Client, callback) => {
-  const authUrl = oAuth2Client.generateAuthUrl({
-    access_type: 'offline',
-    scope: SCOPES,
-  });
-  console.log('Authorize this app by visiting this url:', authUrl);
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  rl.question('Enter the code from that page here: ', (code) => {
-    rl.close();
-    oAuth2Client.getToken(code, (err, token) => {
-      if (err) {
-        return console.error(
-          'Error while trying to retrieve access token', err
-        );
-      }
-      oAuth2Client.setCredentials(token);
-      callback(token);
-    });
-  });
-};
-

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "nodemon",
     "lint": "eslint *.js ./spec/*.js ./lib/*.js actions/**/*.js --fix",
     "start": "probot run ./index.js",
+    "sheets-setup": "node ./sheetsSetup.js",
     "test": "node ./spec/setup.js",
     "actions-build": "ncc build actions/main.js -o actions_build",
     "update-actions-build": "node actions/build.js"

--- a/sheetsSetup.js
+++ b/sheetsSetup.js
@@ -1,0 +1,14 @@
+require('dotenv').config();
+const { getNewToken } = require ('./lib/apiForSheets');
+const { OAuth2Client } = require('google-auth-library');
+(function() {
+  const credentials = JSON.parse(process.env.CLIENT_SECRET);
+  var clientSecret = credentials.installed.client_secret;
+  var clientId = credentials.installed.client_id;
+  var redirectUrl = credentials.installed.redirect_uris[0];
+  var oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUrl);
+  getNewToken(oauth2Client, function(token) {
+    // Logs new sheets access token.
+    console.log('Access Token: ', JSON.stringify(token));
+  });
+})();

--- a/sheetsSetup.js
+++ b/sheetsSetup.js
@@ -1,14 +1,57 @@
 require('dotenv').config();
-const { getNewToken } = require ('./lib/apiForSheets');
+const readline = require('readline');
+const { google } = require('googleapis');
 const { OAuth2Client } = require('google-auth-library');
+
+// If modifying these scopes, delete your previously saved credentials
+// at ~/.credentials/sheets.googleapis.com-nodejs-quickstart.json
+var SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
+
+/**
+ * Get and store new token after prompting for user authorization, and then
+ * execute the given callback with the authorized OAuth2 client.
+ * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
+ * @param {Function} callback The callback for the authorized client.
+ */
+const getNewToken = (oAuth2Client, callback) => {
+  const authUrl = oAuth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+  });
+  console.log('Authorize this app by visiting this url:', authUrl);
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  rl.question('Enter the code from that page here: ', (code) => {
+    rl.close();
+    oAuth2Client.getToken(code, (err, token) => {
+      if (err) {
+        return console.error(
+          'Error while trying to retrieve access token', err
+        );
+      }
+      oAuth2Client.setCredentials(token);
+      callback(token);
+    });
+  });
+};
+
 (function() {
   const credentials = JSON.parse(process.env.CLIENT_SECRET);
-  var clientSecret = credentials.installed.client_secret;
-  var clientId = credentials.installed.client_id;
-  var redirectUrl = credentials.installed.redirect_uris[0];
-  var oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUrl);
+  const clientSecret = credentials.installed.client_secret;
+  const clientId = credentials.installed.client_id;
+  const redirectUrl = credentials.installed.redirect_uris[0];
+  const oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUrl);
+
   getNewToken(oauth2Client, function(token) {
     // Logs new sheets access token.
+    console.log('');
     console.log('Access Token: ', JSON.stringify(token));
+    console.log('');
+    console.log(
+      'Add the newly generated access token to the CREDENTIALS variable in ' +
+      'the .env'
+    );
   });
 })();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
Fixes #195, exposes a simple way to generate google sheets API token for working with the CLA.
Tokens can be generated by running: `npm run sheets-setup`.
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR has been tested at https://github.com/jameesjohn/comment-on-pr/pull/52
## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
