### PR TITLE
Added instruction to remove PRIVATE KEY from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Please refer to the following instructions to setup Oppiabot for the first time 
 
 7. Download the private key. It will be a `.pem` file. Move it to the root directory of the project. As long as it's in the root directory, it will be automatically detected regardless of the filename.
 
+Make sure you remove
+ > PRIVATE_KEY=example_private_key
+from .env file, Otherwise app will not work locally.
+
 8. Edit `.env` and set `APP_ID` to the ID of the app you just created. The App ID can be found in your app settings page here.
 
 <p align="center">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Users or contributors have to remove PRIVATE KEY from Readme.md in order to use Oppiabot Locally Since PRIVATE KEY gets automatically detected by  .pem file. But this gets overlooked since it is mentioned in one of the various comments in .env file. I personally faced this difficulty and also seen some of the other contributors facing the same. I asked it on the Gitter and took more than 1 day to resolve this.  This might not be a big addition but will definitely prove helpful to new contributors.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
