### PR TITLE
Correcting Copy Window 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Please refer to the following instructions to setup Oppiabot for the first time 
   ```
 
 4. The Oppiabot uses environment variables. These are configured in the server settings. To deploy the bot locally, create a `.env` file and copy the contents of `.env.example` to it. You will need to adjust these variables accordingly following the instructions in the subsequent steps. Run following command to copy `.env.example` to `.env`
+
+If using windows cmd and Say you have made folder as instructed in point 1 and on Desktop then run below command, Replace <username> with Name of your computer.
+``` bash
+copy C:\Users\<username>\Desktop\opensource\oppiabot\.env.example  C:\Users\<username>\Desktop\opensource\oppiabot\.env 
+``` 
+else run this command
   ```bash
     cp .env.example .env
   ```

--- a/README.md
+++ b/README.md
@@ -56,15 +56,11 @@ Please refer to the following instructions to setup Oppiabot for the first time 
 
 4. The Oppiabot uses environment variables. These are configured in the server settings. To deploy the bot locally, create a `.env` file and copy the contents of `.env.example` to it. You will need to adjust these variables accordingly following the instructions in the subsequent steps. Run following command to copy `.env.example` to `.env`
 
-If using windows cmd, go to oppiabot folder type
-``` bash 
-echo "%cd%"
-```
-The above command will give you <b>path</b>
+If you're using Windows cmd, go to Oppiabot folder and type:
 ``` bash
-copy  <path>\.env.example <path>\.env 
+copy .env.example .env 
 ``` 
-else run this command
+If you have Linux terminal type:
   ```bash
     cp .env.example .env
   ```

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Please refer to the following instructions to setup Oppiabot for the first time 
 
 4. The Oppiabot uses environment variables. These are configured in the server settings. To deploy the bot locally, create a `.env` file and copy the contents of `.env.example` to it. You will need to adjust these variables accordingly following the instructions in the subsequent steps. Run following command to copy `.env.example` to `.env`
 
-If using windows cmd and Say you have made folder as instructed in point 1 and on Desktop then run below command, Replace <username> with Name of your computer.
+If using windows cmd, go to oppiabot folder type
+``` bash 
+echo "%cd%"
+```
+The above command will give you <b>path</b>
 ``` bash
-copy C:\Users\<username>\Desktop\opensource\oppiabot\.env.example  C:\Users\<username>\Desktop\opensource\oppiabot\.env 
+copy  <path>\.env.example <path>\.env 
 ``` 
 else run this command
   ```bash


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Currently, Command given in README.md works only for Linux-based terminals and there is no command for windows and no instruction either to notify that it not for windows cmd. This may confuse Windows users and create problem for them. I have added an option of copying the .env.example to .env in case user is using Windows. This might not seem to be a bit addition but will definitely prove helpful to new contributors.
## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
