### PR TITLE
Fix: remove redundant space while tagging author

### DIFF
--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -266,7 +266,7 @@ module.exports.checkChangelogLabel = async function (context) {
     'Hi, @' +
     userName +
     ', this pull request does not have a "CHANGELOG: ..." label ' +
-    'as mentioned in the PR pointers. Assigning @ ' +
+    'as mentioned in the PR pointers. Assigning @' +
     userName +
     ' to add the required label. ' +
     'PRs without this label will not be merged. If you are unsure ' +

--- a/spec/checkPullRequestLabelsSpec.js
+++ b/spec/checkPullRequestLabelsSpec.js
@@ -589,7 +589,7 @@ describe('Pull Request Label Check', () => {
           'Hi, @' +
           payloadData.payload.pull_request.user.login +
           ', this pull request does not have a "CHANGELOG: ..." label ' +
-          'as mentioned in the PR pointers. Assigning @ ' +
+          'as mentioned in the PR pointers. Assigning @' +
           payloadData.payload.pull_request.user.login +
           ' to add the required label. ' +
           'PRs without this label will not be merged. If you are unsure ' +


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

- Removed redundant space from oppiabot's comment on adding changelog label.

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
