### PR TITLE
Fix : Oppiabot should be more proactive towards new contributors

### DIFF
--- a/lib/newUserCheck.js
+++ b/lib/newUserCheck.js
@@ -1,0 +1,43 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview File to handle checks when a new user makes a PR.
+ */
+
+const checkNewUser = async (context) => {
+  // Get all issues for repo with user as creator
+  const response = await context.github.issues
+    .listForRepo(context.repo({
+      state: 'all',
+      creator: context.payload.pull_request.user.login
+    }));
+
+  // Creating a welcome message on a new user's first PR
+  const countPR = response.data.filter(data => data.pull_request);
+  if (countPR.length === 1) {
+    try {
+      await context.github.issues.createComment
+      (context.issue({
+        body: 'Welcome!! Good job on opening your first PR.'
+      }));
+    } catch (error) {
+      if (error.code !== 404) {
+        throw error;
+      }
+    }
+  }
+  //Adding more functions for helping new users.
+  //Some feedback required.
+};

--- a/lib/newUserCheck.js
+++ b/lib/newUserCheck.js
@@ -28,8 +28,7 @@ const checkNewUser = async (context) => {
   const countPR = response.data.filter(data => data.pull_request);
   if (countPR.length === 1) {
     try {
-      await context.github.issues.createComment
-      (context.issue({
+      await context.github.issues.createComment(context.issue({
         body: 'Welcome!! Good job on opening your first PR.'
       }));
     } catch (error) {


### PR DESCRIPTION

 Issue #166 Oppiabot should welcome and guide new users when they make their first PR.
  

## Explanation
   Added a newUserCheck to welcome a new user when he opens his/her first PR. Will add more functionalities to guide the user through the review and merge process.
  

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
