### PR TITLE
Fix #175 Fixing ambiguity in oppiabot comments.

### DIFF
--- a/lib/checkForNewCodeowner.js
+++ b/lib/checkForNewCodeowner.js
@@ -24,7 +24,7 @@ const newAddition = '+';
 const newCommentAddition = '+#';
 const newLine = '\n';
 const usernameDefiner = '@';
-const errortodo = '# TODO(#11477)';
+const errortodo = '+# TODO';
 
 /**
  * This function returns true if new added line starts with '+'
@@ -34,8 +34,8 @@ const errortodo = '# TODO(#11477)';
  */
 const checkNewLineAddition = (change) => {
   return (
-    change.startsWith(newAddition) && !change.startsWith(newCommentAddition)
-      && !change.startsWith(errortodo)
+    change.startsWith(newAddition) && !change.startsWith(newCommentAddition) &&
+      !change.startsWith(errortodo)
   );
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Issue #175 : The ambiguous behaviour of oppiabot comments while adding a new code owner is due to TODO 11477 :Replace @rt4914 with @BenHenning after 2021-01-04. This can be seen in the comments  [oppia #11478(comment)](https://github.com/oppia/oppia/pull/11478#issuecomment-749875175), [oppia #11478(comment)](https://github.com/oppia/oppia/pull/11478#issuecomment-749886142).

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
