### PR TITLE
Fix #272: Prevents commenter from being assigned after PTAL comment

### DIFF
--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -315,7 +315,6 @@ const handlePullRequestReview = async (context) => {
  * @param {import('probot').Context} context
  */
 const handleResponseToReview = async (context) => {
-  console.log('EXECUTING');
   /**
    * @type {import('probot').Octokit.IssuesGetResponse}
    */

--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -361,7 +361,7 @@ const handleResponseToReview = async (context) => {
     (assignee) => assignee.login
   );
   const unassignedUsers = usersInComment.filter(
-    (user) => !assignees.includes(user) && !user === commenter
+    (user) => !assignees.includes(user) && user !== commenter
   );
 
   if (unassignedUsers.length === 0) {

--- a/lib/checkPullRequestReview.js
+++ b/lib/checkPullRequestReview.js
@@ -315,6 +315,7 @@ const handlePullRequestReview = async (context) => {
  * @param {import('probot').Context} context
  */
 const handleResponseToReview = async (context) => {
+  console.log('EXECUTING');
   /**
    * @type {import('probot').Octokit.IssuesGetResponse}
    */
@@ -361,7 +362,7 @@ const handleResponseToReview = async (context) => {
     (assignee) => assignee.login
   );
   const unassignedUsers = usersInComment.filter(
-    (user) => !assignees.includes(user)
+    (user) => !assignees.includes(user) && !user === commenter
   );
 
   if (unassignedUsers.length === 0) {

--- a/spec/checkPullRequestReviewSpec.js
+++ b/spec/checkPullRequestReviewSpec.js
@@ -1627,5 +1627,29 @@ describe('Pull Request Review Module', () => {
         commentPayloadData.payload.comment.body = initialCommentBody;
       });
     });
+
+    describe('when commenter self references in comment', () => {
+      const initialCommentBody = commentPayloadData.payload.comment.body;
+      beforeAll(() => {
+        commentPayloadData.payload.comment.body = (
+          '@testuser @reviewer1 PTAL');
+      });
+      beforeEach(async () => {
+        await robot.receive(commentPayloadData);
+      });
+
+      it('should not assign commenter to the PR', () => {
+        expect(github.issues.addAssignees).toHaveBeenCalledWith({
+          repo: commentPayloadData.payload.repository.name,
+          owner: commentPayloadData.payload.repository.owner.login,
+          issue_number: commentPayloadData.payload.issue.number,
+          assignees: ['reviewer1'],
+        });
+      });
+
+      afterAll(() => {
+        commentPayloadData.payload.comment.body = initialCommentBody;
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR fixes #272
Prevents commenter from being assigned after PTAL comment which references the commenter. 

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
