### PR TITLE
Adds a delay for checking changelog labels

### DIFF
--- a/lib/checkPullRequestLabels.js
+++ b/lib/checkPullRequestLabels.js
@@ -24,7 +24,6 @@ const {
   isChangelogLabel,
   pingAndAssignUsers,
   isUserCollaborator,
-  sleep,
   checkPrIsStale
 } = require('./utils');
 const {
@@ -36,7 +35,7 @@ const {
 } = require('../userWhitelist.json');
 const DEFAULT_CHANGELOG_LABEL = 'REVIEWERS: Please add changelog label';
 const PR_LABELS = ['dependencies', 'stale', DEFAULT_CHANGELOG_LABEL];
-
+const utilityModule = require('./utils');
 /**
  * This function tests a changelog label against a regex.
  *
@@ -189,6 +188,18 @@ module.exports.checkChangelogLabel = async function (context) {
    */
   let pullRequest = context.payload.pull_request;
   const pullRequestNumber = pullRequest.number;
+  const THIRTY_SECONDS_IN_MSECS = 30 * 1000;
+
+  await utilityModule.sleep(THIRTY_SECONDS_IN_MSECS);
+
+  // Fetch the pull request again in case the Reviewers list was populated after
+  // a delay.
+  const pullRequestResponse = await context.github.pulls.get(
+    context.repo({
+      pull_number: pullRequestNumber,
+    })
+  );
+  pullRequest = pullRequestResponse.data;
 
   console.log(
     'RUNNING CHANGELOG LABEL CHECK ON PULL REQUEST ' +

--- a/spec/checkPullRequestLabelsSpec.js
+++ b/spec/checkPullRequestLabelsSpec.js
@@ -24,7 +24,7 @@ const checkPullRequestTemplateModule =
   require('../lib/checkPullRequestTemplate');
 const scheduler = require('../lib/scheduler');
 const OLD_BUILD_LABEL = "PR: don't merge - STALE BUILD";
-
+const utilityModule = require('../lib/utils');
 const github = require('@actions/github');
 const core = require('@actions/core');
 const actionPayload = require('../fixtures/pullRequest.labelled.json');
@@ -53,6 +53,7 @@ describe('Pull Request Label Check', () => {
 
   beforeEach(() => {
     spyOn(scheduler, 'createScheduler').and.callFake(() => { });
+    spyOn(utilityModule, 'sleep').and.callFake(() => { });
 
     github = {
       issues: {
@@ -692,6 +693,14 @@ describe('Pull Request Label Check', () => {
   });
 
   describe('when pull request gets opened or reopened', () => {
+    beforeEach(() => {
+      github.pulls = {
+        get: jasmine.createSpy('get').and.resolveTo({
+          data: payloadData.payload.pull_request,
+        }),
+      };
+    });
+
     it('pings pr author when there is no changelog label', async () => {
       payloadData.payload.action = 'reopened';
 
@@ -700,6 +709,7 @@ describe('Pull Request Label Check', () => {
       ).and.callThrough();
       await robot.receive(payloadData);
 
+      expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
       expect(
         checkPullRequestLabelModule.checkChangelogLabel
       ).toHaveBeenCalled();
@@ -754,6 +764,7 @@ describe('Pull Request Label Check', () => {
 
         await robot.receive(payloadData);
 
+        expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
         expect(
           checkPullRequestLabelModule.checkChangelogLabel
         ).toHaveBeenCalled();
@@ -808,6 +819,7 @@ describe('Pull Request Label Check', () => {
 
         await robot.receive(payloadData);
 
+        expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
         expect(
           checkPullRequestLabelModule.checkChangelogLabel
         ).toHaveBeenCalled();
@@ -858,6 +870,7 @@ describe('Pull Request Label Check', () => {
 
         await robot.receive(payloadData);
 
+        expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
         expect(
           checkPullRequestLabelModule.checkChangelogLabel
         ).toHaveBeenCalled();
@@ -921,6 +934,7 @@ describe('Pull Request Label Check', () => {
 
         await robot.receive(payloadData);
 
+        expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
         expect(
           checkPullRequestLabelModule.checkChangelogLabel
         ).toHaveBeenCalled();
@@ -971,6 +985,7 @@ describe('Pull Request Label Check', () => {
       ).and.callThrough();
       await robot.receive(payloadData);
 
+      expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
       expect(
         checkPullRequestLabelModule.checkChangelogLabel
       ).toHaveBeenCalled();
@@ -994,6 +1009,7 @@ describe('Pull Request Label Check', () => {
       ).and.callThrough();
       await robot.receive(payloadData);
 
+      expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
       expect(
         checkPullRequestLabelModule.checkChangelogLabel
       ).toHaveBeenCalled();
@@ -1028,6 +1044,7 @@ describe('Pull Request Label Check', () => {
         ).and.callThrough();
         await robot.receive(payloadData);
 
+        expect(utilityModule.sleep).toHaveBeenCalledWith(30 * 1000);
         expect(
           checkPullRequestLabelModule.checkChangelogLabel
         ).toHaveBeenCalled();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Adds a 30-second delay to checking if the changelog label is present. This is done to prevent cases where the PR payload is sent prior to the reviewers being assigned to the PR.

## Checklist
- [x] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [x] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
