### PR TITLE
Update web tech leads team alias.

### DIFF
--- a/spec/periodicChecksSpec.js
+++ b/spec/periodicChecksSpec.js
@@ -523,7 +523,7 @@ describe('Periodic Checks Module', () => {
         owner: 'oppia',
         repo: 'oppia',
         body:
-          'Hi @DubeySandeep, @oppia/core-maintainers ' +
+          'Hi @DubeySandeep, @oppia/web-tech-leads ' +
           'I cannot decide what to do with this PR, ' +
           'please assign reviewers manually thanks!',
       });
@@ -765,14 +765,14 @@ describe('Periodic Checks Module', () => {
         });
       });
 
-      it('should ping core maintainers', () => {
+      it('should ping web tech leads', () => {
         expect(github.issues.createComment).toHaveBeenCalled();
         expect(github.issues.createComment).toHaveBeenCalledWith({
           owner: 'oppia',
           repo: 'oppia',
           issue_number: 1,
           body:
-            'Hi @oppia/core-maintainers, this issue is not assigned ' +
+            'Hi @oppia/web-tech-leads, this issue is not assigned ' +
             'to any project. Can you please update the same? Thanks!',
         });
       });

--- a/userWhitelist.json
+++ b/userWhitelist.json
@@ -29,7 +29,7 @@
     "releaseTeam": "vojtechjelinek",
     "welfareTeam": "DubeySandeep"
   },
-  "oppiaMaintainers": "oppia/core-maintainers",
+  "oppiaMaintainers": "oppia/web-tech-leads",
   "oppiaReleaseCoordinators": "oppia/release-coordinators",
   "oppiaDevWorkflowTeam": "oppia/dev-workflow-team",
   "serverJobAdmins": ["U8NWXD", "kevintab95"]


### PR DESCRIPTION
## Explanation

Change the core-maintainers team alias to web-tech-leads.

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
