### PR TITLE
Create codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/ @oppia/dev-workflow-reviewers
+* @oppia/dev-workflow-reviewers
 /package.json @oppia/dependency-reviewers


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppiabot! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

Creates codeowners file, which specifies that everything is owned by the dev-workflow team, except for `packages.json`, which is owned by the dependency reviewers team.

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
