### PR TITLE
Add link to wiki when asking contributors to file a flake report.

### DIFF
--- a/lib/ciChecks.js
+++ b/lib/ciChecks.js
@@ -49,8 +49,8 @@ const handleFailure = async (context) => {
       const commentBody =
         'Hi @' +
         prAuthor +
-        ', there are some failing CI checks in your latest push ' +
-        ' If you think this is due to a flake, please file an issue before ' +
+        ', there are some failing CI checks in your latest push. ' +
+        'If you think this is due to a flake, please file an issue before ' +
         'restarting the tests (see [instructions](https://github.com/oppia' +
         '/oppia/wiki/If-CI-checks-fail-on-your-PR)). Thanks!';
       await pingAndAssignUsers(context, pullRequest, [prAuthor], commentBody);

--- a/spec/ciChecksSpec.js
+++ b/spec/ciChecksSpec.js
@@ -107,8 +107,8 @@ describe('CI Checks', () => {
         body:
           'Hi @' +
           prAuthor +
-          ', there are some failing CI checks in your latest push ' +
-          ' If you think this is due to a flake, please file an issue before ' +
+          ', there are some failing CI checks in your latest push. ' +
+          'If you think this is due to a flake, please file an issue before ' +
           'restarting the tests (see [instructions](https://github.com/oppia' +
           '/oppia/wiki/If-CI-checks-fail-on-your-PR)). Thanks!',
       });


### PR DESCRIPTION
## Explanation
Adds a link to the "please file an issue" message with instructions on how to detect and handle flakes.

## Checklist
- [ ] I have successfully deployed my own instance of Oppiabot.
  - You can find instructions for doing this [here](https://github.com/oppia/oppiabot/wiki/Deploying-your-own-instance-of-the-oppiabot).
- [ ] I have manually tested all the changes made in this PR following the [manual tests matrix](https://github.com/oppia/oppiabot/wiki/Manual-Tests-Matrix).
